### PR TITLE
Add real-time spectrum analyzer with RMS metering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,7 @@ set(APP_SOURCES
     src/audio/effects/compressor.cpp
     src/audio/effects/cabinet_sim.cpp
     src/gui/gui_manager.cpp
+    src/gui/spectrum_analyzer.cpp
     src/gui/pedal_board.cpp
     src/gui/pedal_widget.cpp
     src/gui/command_history.cpp

--- a/src/audio/audio_engine.cpp
+++ b/src/audio/audio_engine.cpp
@@ -123,13 +123,37 @@ void AudioEngine::process_audio(const float* input, float* output, int frame_cou
     // Drain lock-free command queue (GUI -> Audio)
     drain_commands();
 
+    // Single branch: read once per callback, not per sample.
+    const bool analyzer_on = analyzer_enabled_.load(std::memory_order_relaxed);
+
     // Copy input to processing buffer with gain
     float in_gain = input_gain_.load(std::memory_order_relaxed);
     float peak_in = 0.0f;
-    for (int i = 0; i < frame_count; ++i) {
-        process_buffer_[i] = input[i] * in_gain;
-        float abs_val = std::fabs(process_buffer_[i]);
-        if (abs_val > peak_in) peak_in = abs_val;
+    if (analyzer_on) {
+        // --- Analyzer-active path: also computes RMS, clipping, and ring-buffer capture ---
+        float sum_sq_in = 0.0f;
+        bool clipped_in = false;
+        int cap = analyzer_capture_index_;
+        for (int i = 0; i < frame_count; ++i) {
+            process_buffer_[i] = input[i] * in_gain;
+            float abs_val = std::fabs(process_buffer_[i]);
+            if (abs_val > peak_in) peak_in = abs_val;
+            if (abs_val >= 1.0f) clipped_in = true;
+            sum_sq_in += process_buffer_[i] * process_buffer_[i];
+            analyzer_capture_input_[cap] = process_buffer_[i];
+            cap = (cap + 1) & ANALYZER_FFT_MASK;
+        }
+        input_rms_.store(std::sqrt(sum_sq_in / std::max(frame_count, 1)), std::memory_order_relaxed);
+        if (clipped_in) input_clipped_.store(true, std::memory_order_release);
+        // cap is carried forward for the output loop below
+        analyzer_capture_index_ = cap;
+    } else {
+        // --- Original zero-overhead path: peak metering only ---
+        for (int i = 0; i < frame_count; ++i) {
+            process_buffer_[i] = input[i] * in_gain;
+            float abs_val = std::fabs(process_buffer_[i]);
+            if (abs_val > peak_in) peak_in = abs_val;
+        }
     }
     input_level_.store(peak_in);
 
@@ -148,11 +172,56 @@ void AudioEngine::process_audio(const float* input, float* output, int frame_cou
     // Copy to output with gain
     float out_gain = output_gain_.load(std::memory_order_relaxed);
     float peak_out = 0.0f;
-    for (int i = 0; i < frame_count; ++i) {
-        output[i] = process_buffer_[i] * out_gain;
-        output[i] = clamp(output[i], -1.0f, 1.0f);
-        float abs_val = std::fabs(output[i]);
-        if (abs_val > peak_out) peak_out = abs_val;
+    if (analyzer_on) {
+        // --- Analyzer-active path ---
+        float sum_sq_out = 0.0f;
+        bool clipped_out = false;
+        int cap = (analyzer_capture_index_ - frame_count) & ANALYZER_FFT_MASK;
+        for (int i = 0; i < frame_count; ++i) {
+            float out_sample = process_buffer_[i] * out_gain;
+            if (std::fabs(out_sample) >= 1.0f) clipped_out = true;
+            output[i] = clamp(out_sample, -1.0f, 1.0f);
+            float abs_val = std::fabs(output[i]);
+            if (abs_val > peak_out) peak_out = abs_val;
+            sum_sq_out += output[i] * output[i];
+            analyzer_capture_output_[cap] = output[i];
+            cap = (cap + 1) & ANALYZER_FFT_MASK;
+        }
+        output_rms_.store(std::sqrt(sum_sq_out / std::max(frame_count, 1)), std::memory_order_relaxed);
+        if (clipped_out) output_clipped_.store(true, std::memory_order_release);
+
+        // Publish snapshot at hop cadence (non-blocking)
+        analyzer_samples_since_publish_ += frame_count;
+        if (analyzer_samples_since_publish_ >= ANALYZER_HOP_SIZE) {
+            if (analyzer_mutex_.try_lock()) {
+                // Reorder ring buffer into contiguous time-domain snapshot
+                const int start = analyzer_capture_index_;
+                const int first_chunk = ANALYZER_FFT_SIZE - start;
+                std::memcpy(analyzer_snapshot_input_.data(),
+                            analyzer_capture_input_.data() + start,
+                            static_cast<size_t>(first_chunk) * sizeof(float));
+                std::memcpy(analyzer_snapshot_input_.data() + first_chunk,
+                            analyzer_capture_input_.data(),
+                            static_cast<size_t>(start) * sizeof(float));
+                std::memcpy(analyzer_snapshot_output_.data(),
+                            analyzer_capture_output_.data() + start,
+                            static_cast<size_t>(first_chunk) * sizeof(float));
+                std::memcpy(analyzer_snapshot_output_.data() + first_chunk,
+                            analyzer_capture_output_.data(),
+                            static_cast<size_t>(start) * sizeof(float));
+                analyzer_sequence_.fetch_add(1, std::memory_order_release);
+                analyzer_samples_since_publish_ = 0;
+                analyzer_mutex_.unlock();
+            }
+        }
+    } else {
+        // --- Original zero-overhead path ---
+        for (int i = 0; i < frame_count; ++i) {
+            output[i] = process_buffer_[i] * out_gain;
+            output[i] = clamp(output[i], -1.0f, 1.0f);
+            float abs_val = std::fabs(output[i]);
+            if (abs_val > peak_out) peak_out = abs_val;
+        }
     }
     output_level_.store(peak_out);
 
@@ -277,6 +346,25 @@ int AudioEngine::get_suggested_buffer_size() const {
         }
     }
     return current;  // no change
+}
+
+bool AudioEngine::copy_analyzer_snapshot(float* input_dest,
+                                         float* output_dest,
+                                         int sample_count) const {
+    if (!input_dest || !output_dest || sample_count <= 0) {
+        return false;
+    }
+
+    const int count = std::min(sample_count, ANALYZER_FFT_SIZE);
+    std::lock_guard<std::mutex> lock(analyzer_mutex_);
+    const uint64_t seq = analyzer_sequence_.load(std::memory_order_relaxed);
+    if (seq == 0) {
+        return false;
+    }
+
+    std::memcpy(input_dest, analyzer_snapshot_input_.data(), static_cast<size_t>(count) * sizeof(float));
+    std::memcpy(output_dest, analyzer_snapshot_output_.data(), static_cast<size_t>(count) * sizeof(float));
+    return true;
 }
 
 } // namespace GuitarAmp

--- a/src/audio/audio_engine.h
+++ b/src/audio/audio_engine.h
@@ -147,6 +147,42 @@ public:
     /** @brief Return the most recent output peak level (0.0–1.0, atomic). */
     float get_output_level() const { return output_level_.load(); }
 
+    /** @brief Return the most recent input RMS level (0.0–1.0, atomic). */
+    float get_input_rms() const { return input_rms_.load(std::memory_order_relaxed); }
+
+    /** @brief Return the most recent output RMS level (0.0–1.0, atomic). */
+    float get_output_rms() const { return output_rms_.load(std::memory_order_relaxed); }
+
+    /** @brief Consume one-shot input clipping flag set by audio thread. */
+    bool consume_input_clipped() { return input_clipped_.exchange(false, std::memory_order_acq_rel); }
+
+    /** @brief Consume one-shot output clipping flag set by audio thread. */
+    bool consume_output_clipped() { return output_clipped_.exchange(false, std::memory_order_acq_rel); }
+
+    /** @brief FFT size used for GUI analyzer snapshots. */
+    static constexpr int ANALYZER_FFT_SIZE = 2048;
+    static constexpr int ANALYZER_FFT_MASK = ANALYZER_FFT_SIZE - 1;
+
+    /** @brief Enable/disable analyzer capture in the audio callback (GUI thread). */
+    void set_analyzer_enabled(bool enabled) { analyzer_enabled_.store(enabled, std::memory_order_release); }
+
+    /** @brief Return true if analyzer capture is active. */
+    bool is_analyzer_enabled() const { return analyzer_enabled_.load(std::memory_order_acquire); }
+
+    /** @brief Snapshot sequence counter; increments when new analyzer data is published. */
+    uint64_t get_analyzer_sequence() const {
+        return analyzer_sequence_.load(std::memory_order_acquire);
+    }
+
+    /**
+     * @brief Copy latest pre/post-chain analyzer snapshots (GUI thread).
+     * @param input_dest  Destination buffer for pre-chain samples.
+     * @param output_dest Destination buffer for post-chain samples.
+     * @param sample_count Number of samples to copy (clamped to ANALYZER_FFT_SIZE).
+     * @return true if at least one snapshot has been published.
+     */
+    bool copy_analyzer_snapshot(float* input_dest, float* output_dest, int sample_count) const;
+
     /**
      * @brief Set the master input gain (enqueued to audio thread via SPSC queue).
      * @param gain Linear gain multiplier.
@@ -227,6 +263,11 @@ private:
 
     std::atomic<float> input_level_{0.0f};
     std::atomic<float> output_level_{0.0f};
+    std::atomic<float> input_rms_{0.0f};
+    std::atomic<float> output_rms_{0.0f};
+    std::atomic<bool> input_clipped_{false};
+    std::atomic<bool> output_clipped_{false};
+    std::atomic<bool> analyzer_enabled_{false};
 
     std::vector<std::shared_ptr<Effect>> effects_;
     std::vector<float> process_buffer_;
@@ -242,6 +283,19 @@ private:
     std::atomic<float> cpu_load_{0.0f};
     std::atomic<float> callback_duration_us_{0.0f};
     bool auto_buffer_enabled_ = false;
+
+    // Audio-thread capture for GUI analyzer snapshots.
+    static constexpr int ANALYZER_HOP_SIZE = 1024;
+    std::array<float, ANALYZER_FFT_SIZE> analyzer_capture_input_{};
+    std::array<float, ANALYZER_FFT_SIZE> analyzer_capture_output_{};
+    int analyzer_capture_index_ = 0;
+    int analyzer_samples_since_publish_ = 0;
+
+    // Shared snapshot buffers (audio thread writes with try_lock, GUI reads with lock).
+    mutable std::mutex analyzer_mutex_;
+    std::array<float, ANALYZER_FFT_SIZE> analyzer_snapshot_input_{};
+    std::array<float, ANALYZER_FFT_SIZE> analyzer_snapshot_output_{};
+    std::atomic<uint64_t> analyzer_sequence_{0};
 };
 
 } // namespace GuitarAmp

--- a/src/gui/gui_manager.cpp
+++ b/src/gui/gui_manager.cpp
@@ -22,7 +22,8 @@
 namespace GuitarAmp {
 
 GuiManager::GuiManager(AudioEngine& engine)
-    : engine_(engine) {}
+    : engine_(engine),
+      spectrum_analyzer_(std::make_unique<SpectrumAnalyzer>()) {}
 
 std::string GuiManager::preset_name_from_path(const std::string& filepath) const {
     size_t slash = filepath.find_last_of("/\\");
@@ -411,10 +412,15 @@ bool GuiManager::run_frame() {
 
     ImGui::Separator();
 
-    // Pedal board area
+    float analyzer_reserved_h = analyzer_panel_expanded_ ? 245.0f : 38.0f;
+    ImGui::BeginChild("PedalBoardRegion", ImVec2(0, -analyzer_reserved_h), false);
     if (pedal_board_) {
         pedal_board_->render();
     }
+    ImGui::EndChild();
+
+    ImGui::Separator();
+    render_analyzer_panel();
 
     ImGui::End();
 
@@ -443,6 +449,145 @@ bool GuiManager::run_frame() {
     SDL_GL_SwapWindow(window_);
 
     return true;
+}
+
+void GuiManager::render_vu_bar(const char* id,
+                               const char* label,
+                               float rms_level,
+                               float peak_hold,
+                               bool clip_active,
+                               float clip_flash,
+                               ImU32 base_color,
+                               ImU32 peak_color) {
+    ImGui::PushID(id);
+    ImGui::TextUnformatted(label);
+    ImGui::SameLine();
+    float db_value = (rms_level > 0.0001f) ? (20.0f * std::log10(rms_level)) : -96.0f;
+    ImGui::TextColored(ImVec4(0.80f, 0.80f, 0.80f, 1.0f), "%.1f dB", db_value);
+
+    ImVec2 pos = ImGui::GetCursorScreenPos();
+    float width = ImGui::GetContentRegionAvail().x;
+    float height = 18.0f;
+    ImDrawList* dl = ImGui::GetWindowDrawList();
+
+    ImU32 bg_col = Theme::METER_BG;
+    if (clip_active || clip_flash > 0.01f) {
+        const float flash = clamp(clip_flash, 0.0f, 1.0f);
+        int alpha = static_cast<int>(90.0f + flash * 130.0f);
+        bg_col = IM_COL32(180, 30, 30, alpha);
+    }
+
+    dl->AddRectFilled(pos, ImVec2(pos.x + width, pos.y + height), bg_col, Theme::ROUNDING_SM);
+
+    float rms_fill = clamp(rms_level, 0.0f, 1.0f) * width;
+    dl->AddRectFilled(pos, ImVec2(pos.x + rms_fill, pos.y + height), base_color, Theme::ROUNDING_SM);
+
+    float peak_x = pos.x + clamp(peak_hold, 0.0f, 1.0f) * width;
+    dl->AddLine(ImVec2(peak_x, pos.y - 1.0f), ImVec2(peak_x, pos.y + height + 1.0f), peak_color, 2.0f);
+
+    if (clip_active || clip_flash > 0.01f) {
+        dl->AddText(ImVec2(pos.x + width - 32.0f, pos.y - 1.0f), IM_COL32(255, 90, 90, 255), "CLIP");
+    }
+
+    ImGui::Dummy(ImVec2(width, height + 6.0f));
+    ImGui::PopID();
+}
+
+void GuiManager::render_analyzer_panel() {
+    float panel_h = analyzer_panel_expanded_ ? 230.0f : 34.0f;
+    ImGui::BeginChild("AnalyzerPanel", ImVec2(0, panel_h), true, ImGuiWindowFlags_NoScrollbar);
+
+    const bool expanded = ImGui::CollapsingHeader("Real-Time Analyzer", ImGuiTreeNodeFlags_DefaultOpen);
+    analyzer_panel_expanded_ = expanded;
+    engine_.set_analyzer_enabled(expanded);
+    if (!expanded) {
+        ImGui::EndChild();
+        return;
+    }
+
+    const float dt = std::max(ImGui::GetIO().DeltaTime, 1.0f / 240.0f);
+
+    const float input_rms = engine_.get_input_rms();
+    const float output_rms = engine_.get_output_rms();
+    smoothed_input_rms_ += (input_rms - smoothed_input_rms_) * 0.22f;
+    smoothed_output_rms_ += (output_rms - smoothed_output_rms_) * 0.22f;
+
+    const float peak_decay = 0.45f;
+    input_rms_peak_hold_ = std::max(smoothed_input_rms_, input_rms_peak_hold_ - peak_decay * dt);
+    output_rms_peak_hold_ = std::max(smoothed_output_rms_, output_rms_peak_hold_ - peak_decay * dt);
+
+    const bool input_clipped = engine_.consume_input_clipped();
+    const bool output_clipped = engine_.consume_output_clipped();
+    if (input_clipped) input_clip_flash_ = 1.0f;
+    if (output_clipped) output_clip_flash_ = 1.0f;
+    input_clip_flash_ = std::max(0.0f, input_clip_flash_ - dt * 2.0f);
+    output_clip_flash_ = std::max(0.0f, output_clip_flash_ - dt * 2.0f);
+
+    int mode_index = static_cast<int>(analyzer_mode_);
+    ImGui::TextUnformatted("Spectrum:");
+    ImGui::SameLine();
+    ImGui::SetNextItemWidth(150.0f);
+    if (ImGui::Combo("##AnalyzerMode", &mode_index, "Input\0Output\0Overlay\0")) {
+        analyzer_mode_ = static_cast<SpectrumAnalyzer::DisplayMode>(mode_index);
+    }
+
+    ImGui::Columns(2, "analyzer_vu_cols", false);
+    render_vu_bar("input_vu",
+                  "INPUT RMS",
+                  smoothed_input_rms_,
+                  input_rms_peak_hold_,
+                  input_clipped,
+                  input_clip_flash_,
+                  IM_COL32(60, 200, 110, 230),
+                  IM_COL32(255, 230, 120, 255));
+    ImGui::NextColumn();
+    render_vu_bar("output_vu",
+                  "OUTPUT RMS",
+                  smoothed_output_rms_,
+                  output_rms_peak_hold_,
+                  output_clipped,
+                  output_clip_flash_,
+                  IM_COL32(80, 170, 245, 230),
+                  IM_COL32(255, 230, 120, 255));
+    ImGui::Columns(1);
+
+    const uint64_t analyzer_seq = engine_.get_analyzer_sequence();
+    if (analyzer_seq != analyzer_last_sequence_) {
+        if (engine_.copy_analyzer_snapshot(analyzer_input_buf_.data(),
+                                           analyzer_output_buf_.data(),
+                                           AudioEngine::ANALYZER_FFT_SIZE)) {
+            spectrum_analyzer_->update(analyzer_input_buf_.data(),
+                                       analyzer_output_buf_.data(),
+                                       engine_.get_sample_rate(),
+                                       dt);
+            analyzer_last_sequence_ = analyzer_seq;
+        }
+    }
+
+    ImVec2 plot_pos = ImGui::GetCursorScreenPos();
+    ImVec2 plot_size(ImGui::GetContentRegionAvail().x, 112.0f);
+    ImDrawList* dl = ImGui::GetWindowDrawList();
+
+    dl->AddRectFilled(plot_pos,
+                      ImVec2(plot_pos.x + plot_size.x, plot_pos.y + plot_size.y),
+                      IM_COL32(20, 22, 28, 255),
+                      Theme::ROUNDING_SM);
+
+    if (spectrum_analyzer_) {
+        spectrum_analyzer_->draw(dl, plot_pos, plot_size, analyzer_mode_);
+    }
+
+    ImGui::Dummy(plot_size);
+
+    const float axis_left = ImGui::GetCursorPosX();
+    const float axis_w = ImGui::GetContentRegionAvail().x;
+    ImGui::TextColored(Theme::TextSecondary(), "20 Hz");
+    ImGui::SameLine(axis_left + axis_w * 0.48f);
+    ImGui::TextColored(Theme::TextSecondary(), "1 kHz");
+    ImGui::SameLine(axis_left + axis_w - 52.0f);
+    ImGui::TextColored(Theme::TextSecondary(), "20 kHz");
+
+    ImGui::EndChild();
 }
 
 void GuiManager::render_menu_bar() {

--- a/src/gui/gui_manager.h
+++ b/src/gui/gui_manager.h
@@ -4,6 +4,7 @@
 #include "audio/audio_engine.h"
 #include "preset_manager.h"
 #include "gui/command_history.h"
+#include "gui/spectrum_analyzer.h"
 
 struct SDL_Window;
 typedef void* SDL_GLContext;
@@ -74,11 +75,24 @@ private:
     /** @brief Render the "Load Preset" popup dialog. */
     void render_load_preset_popup();
 
-    /** @brief Render the recording start/stop controls. */
+    /** @brief Render recording start/stop controls. */
     void render_recording_controls();
 
     /** @brief Render the "Save Recording" file dialog. */
     void render_recording_save_dialog();
+
+    /** @brief Render the collapsible VU + spectrum analyzer panel. */
+    void render_analyzer_panel();
+
+    /** @brief Draw a horizontal VU bar with peak hold and clipping flash. */
+    void render_vu_bar(const char* id,
+                       const char* label,
+                       float rms_level,
+                       float peak_hold,
+                       bool clip_active,
+                       float clip_flash,
+                       ImU32 base_color,
+                       ImU32 peak_color);
 
     void refresh_presets(bool preserve_selection = true);
     bool save_named_preset(const std::string& preset_name,
@@ -114,6 +128,19 @@ private:
     // Smoothed meter values
     float smoothed_input_level_ = 0.0f;
     float smoothed_output_level_ = 0.0f;
+    float smoothed_input_rms_ = 0.0f;
+    float smoothed_output_rms_ = 0.0f;
+    float input_rms_peak_hold_ = 0.0f;
+    float output_rms_peak_hold_ = 0.0f;
+    float input_clip_flash_ = 0.0f;
+    float output_clip_flash_ = 0.0f;
+
+    bool analyzer_panel_expanded_ = true;
+    SpectrumAnalyzer::DisplayMode analyzer_mode_ = SpectrumAnalyzer::DisplayMode::Output;
+    std::unique_ptr<SpectrumAnalyzer> spectrum_analyzer_;
+    std::array<float, AudioEngine::ANALYZER_FFT_SIZE> analyzer_input_buf_{};
+    std::array<float, AudioEngine::ANALYZER_FFT_SIZE> analyzer_output_buf_{};
+    uint64_t analyzer_last_sequence_ = 0;
 
     // Recording UI state
     bool show_recording_save_ = false;

--- a/src/gui/spectrum_analyzer.cpp
+++ b/src/gui/spectrum_analyzer.cpp
@@ -1,0 +1,197 @@
+#include "gui/spectrum_analyzer.h"
+#include "gui/theme.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace GuitarAmp {
+
+namespace {
+
+constexpr float kMinHz = 20.0f;
+constexpr float kMaxHz = 20000.0f;
+constexpr float kMinDb = -90.0f;
+constexpr float kMaxDb = 0.0f;
+
+inline float lerp(float a, float b, float t) {
+    return a + (b - a) * t;
+}
+
+inline float hz_to_log_norm(float hz) {
+    const float lo = std::log10(kMinHz);
+    const float hi = std::log10(kMaxHz);
+    return clamp((std::log10(hz) - lo) / (hi - lo), 0.0f, 1.0f);
+}
+
+} // namespace
+
+SpectrumAnalyzer::SpectrumAnalyzer() {
+    for (int i = 0; i < FFT_SIZE; ++i) {
+        const float phase = (TWO_PI * static_cast<float>(i)) / static_cast<float>(FFT_SIZE - 1);
+        window_[i] = 0.5f * (1.0f - std::cos(phase));
+    }
+
+    smoothed_input_db_.fill(kMinDb);
+    smoothed_output_db_.fill(kMinDb);
+    input_peak_db_.fill(kMinDb);
+    output_peak_db_.fill(kMinDb);
+}
+
+void SpectrumAnalyzer::run_fft(std::array<std::complex<float>, FFT_SIZE>& data) const {
+    for (int i = 1, j = 0; i < FFT_SIZE; ++i) {
+        int bit = FFT_SIZE >> 1;
+        for (; (j & bit) != 0; bit >>= 1) {
+            j ^= bit;
+        }
+        j ^= bit;
+        if (i < j) {
+            std::swap(data[i], data[j]);
+        }
+    }
+
+    for (int len = 2; len <= FFT_SIZE; len <<= 1) {
+        const float angle = -TWO_PI / static_cast<float>(len);
+        const std::complex<float> wlen(std::cos(angle), std::sin(angle));
+        for (int i = 0; i < FFT_SIZE; i += len) {
+            std::complex<float> w(1.0f, 0.0f);
+            const int half = len >> 1;
+            for (int j = 0; j < half; ++j) {
+                const std::complex<float> u = data[i + j];
+                const std::complex<float> v = data[i + j + half] * w;
+                data[i + j] = u + v;
+                data[i + j + half] = u - v;
+                w *= wlen;
+            }
+        }
+    }
+}
+
+void SpectrumAnalyzer::compute_spectrum_bars(const float* samples,
+                                             int sample_rate,
+                                             std::array<float, DISPLAY_BARS>& bars_db) {
+    if (!samples || sample_rate <= 0) {
+        bars_db.fill(kMinDb);
+        return;
+    }
+
+    for (int i = 0; i < FFT_SIZE; ++i) {
+        fft_work_[i] = std::complex<float>(samples[i] * window_[i], 0.0f);
+    }
+
+    run_fft(fft_work_);
+
+    std::array<float, FFT_BINS> mags_db{};
+    mags_db.fill(kMinDb);
+
+    const float norm = 2.0f / static_cast<float>(FFT_SIZE);
+    for (int i = 1; i < FFT_BINS; ++i) {
+        const float mag = std::abs(fft_work_[i]) * norm;
+        mags_db[i] = clamp(20.0f * std::log10(std::max(mag, 1e-8f)), kMinDb, kMaxDb);
+    }
+
+    for (int bar = 0; bar < DISPLAY_BARS; ++bar) {
+        const float t0 = static_cast<float>(bar) / static_cast<float>(DISPLAY_BARS);
+        const float t1 = static_cast<float>(bar + 1) / static_cast<float>(DISPLAY_BARS);
+        const float hz0 = std::pow(10.0f, lerp(std::log10(kMinHz), std::log10(kMaxHz), t0));
+        const float hz1 = std::pow(10.0f, lerp(std::log10(kMinHz), std::log10(kMaxHz), t1));
+
+        int bin0 = static_cast<int>(hz0 * FFT_SIZE / static_cast<float>(sample_rate));
+        int bin1 = static_cast<int>(hz1 * FFT_SIZE / static_cast<float>(sample_rate));
+        bin0 = std::max(1, std::min(bin0, FFT_BINS - 1));
+        bin1 = std::max(bin0 + 1, std::min(bin1, FFT_BINS));
+
+        float peak_db = kMinDb;
+        for (int b = bin0; b < bin1; ++b) {
+            peak_db = std::max(peak_db, mags_db[b]);
+        }
+        bars_db[bar] = peak_db;
+    }
+}
+
+void SpectrumAnalyzer::update(const float* input_samples,
+                              const float* output_samples,
+                              int sample_rate,
+                              float dt_seconds) {
+    std::array<float, DISPLAY_BARS> input_db{};
+    std::array<float, DISPLAY_BARS> output_db{};
+    compute_spectrum_bars(input_samples, sample_rate, input_db);
+    compute_spectrum_bars(output_samples, sample_rate, output_db);
+
+    const float smooth_alpha = 0.26f;
+    const float peak_decay_db_per_sec = 30.0f;
+    const float decay = peak_decay_db_per_sec * std::max(dt_seconds, 1.0f / 240.0f);
+
+    for (int i = 0; i < DISPLAY_BARS; ++i) {
+        smoothed_input_db_[i] = lerp(smoothed_input_db_[i], input_db[i], smooth_alpha);
+        smoothed_output_db_[i] = lerp(smoothed_output_db_[i], output_db[i], smooth_alpha);
+
+        input_peak_db_[i] = std::max(smoothed_input_db_[i], input_peak_db_[i] - decay);
+        output_peak_db_[i] = std::max(smoothed_output_db_[i], output_peak_db_[i] - decay);
+    }
+}
+
+void SpectrumAnalyzer::draw(ImDrawList* draw_list,
+                            const ImVec2& pos,
+                            const ImVec2& size,
+                            DisplayMode mode) const {
+    if (!draw_list || size.x <= 2.0f || size.y <= 2.0f) {
+        return;
+    }
+
+    const ImVec2 pmax(pos.x + size.x, pos.y + size.y);
+    draw_list->AddRect(pos, pmax, IM_COL32(72, 78, 92, 220), Theme::ROUNDING_SM);
+
+    const float ref_lines[] = {-60.0f, -48.0f, -36.0f, -24.0f, -12.0f};
+    for (float db : ref_lines) {
+        float t = (db - kMinDb) / (kMaxDb - kMinDb);
+        float y = pmax.y - t * size.y;
+        draw_list->AddLine(ImVec2(pos.x, y), ImVec2(pmax.x, y), IM_COL32(58, 64, 76, 180), 1.0f);
+    }
+
+    const ImU32 input_col = IM_COL32(82, 220, 135, 220);
+    const ImU32 output_col = IM_COL32(92, 170, 255, 220);
+    const ImU32 peak_col = IM_COL32(255, 240, 165, 255);
+
+    const auto draw_set = [&](const std::array<float, DISPLAY_BARS>& bars,
+                              const std::array<float, DISPLAY_BARS>& peaks,
+                              ImU32 bar_col,
+                              float width_scale) {
+        for (int i = 0; i < DISPLAY_BARS; ++i) {
+            const float x0 = pos.x + (static_cast<float>(i) / DISPLAY_BARS) * size.x;
+            const float x1 = pos.x + (static_cast<float>(i + 1) / DISPLAY_BARS) * size.x;
+            const float db = clamp(bars[i], kMinDb, kMaxDb);
+            const float t = (db - kMinDb) / (kMaxDb - kMinDb);
+            const float y = pmax.y - t * size.y;
+
+            const float center = (x0 + x1) * 0.5f;
+            const float half = (x1 - x0) * 0.5f * width_scale;
+            draw_list->AddRectFilled(ImVec2(center - half, y), ImVec2(center + half, pmax.y), bar_col, 1.5f);
+
+            const float peak_db = clamp(peaks[i], kMinDb, kMaxDb);
+            const float peak_t = (peak_db - kMinDb) / (kMaxDb - kMinDb);
+            const float py = pmax.y - peak_t * size.y;
+            draw_list->AddLine(ImVec2(center - half, py), ImVec2(center + half, py), peak_col, 1.0f);
+        }
+    };
+
+    switch (mode) {
+        case DisplayMode::Input:
+            draw_set(smoothed_input_db_, input_peak_db_, input_col, 0.82f);
+            break;
+        case DisplayMode::Output:
+            draw_set(smoothed_output_db_, output_peak_db_, output_col, 0.82f);
+            break;
+        case DisplayMode::Overlay:
+            draw_set(smoothed_input_db_, input_peak_db_, input_col, 0.42f);
+            draw_set(smoothed_output_db_, output_peak_db_, output_col, 0.42f);
+            break;
+    }
+
+    const float ticks[] = {20.0f, 100.0f, 1000.0f, 5000.0f, 10000.0f, 20000.0f};
+    for (float hz : ticks) {
+        float x = pos.x + hz_to_log_norm(hz) * size.x;
+        draw_list->AddLine(ImVec2(x, pos.y), ImVec2(x, pmax.y), IM_COL32(52, 58, 72, 180), 1.0f);
+    }
+}
+
+} // namespace GuitarAmp

--- a/src/gui/spectrum_analyzer.h
+++ b/src/gui/spectrum_analyzer.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "common.h"
+#include <imgui.h>
+#include <array>
+#include <complex>
+
+namespace GuitarAmp {
+
+class SpectrumAnalyzer {
+public:
+    static constexpr int FFT_SIZE = 2048;
+    static constexpr int FFT_BINS = FFT_SIZE / 2;
+    static constexpr int DISPLAY_BARS = 96;
+
+    enum class DisplayMode {
+        Input = 0,
+        Output = 1,
+        Overlay = 2,
+    };
+
+    SpectrumAnalyzer();
+
+    void update(const float* input_samples,
+                const float* output_samples,
+                int sample_rate,
+                float dt_seconds);
+
+    void draw(ImDrawList* draw_list,
+              const ImVec2& pos,
+              const ImVec2& size,
+              DisplayMode mode) const;
+
+private:
+    void compute_spectrum_bars(const float* samples,
+                               int sample_rate,
+                               std::array<float, DISPLAY_BARS>& bars_db);
+    void run_fft(std::array<std::complex<float>, FFT_SIZE>& data) const;
+
+    std::array<float, FFT_SIZE> window_{};
+    std::array<std::complex<float>, FFT_SIZE> fft_work_{};
+
+    std::array<float, DISPLAY_BARS> smoothed_input_db_{};
+    std::array<float, DISPLAY_BARS> smoothed_output_db_{};
+    std::array<float, DISPLAY_BARS> input_peak_db_{};
+    std::array<float, DISPLAY_BARS> output_peak_db_{};
+};
+
+} // namespace GuitarAmp


### PR DESCRIPTION
Closes #15 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added real-time frequency spectrum analyzer with selectable display modes (Input, Output, or Overlay visualization)
* Added VU meters for input and output signal levels with RMS readings, peak hold tracking, and dB scaling
* Integrated audio clipping detection with visual flash indicator for both input and output channels
* Analyzer features can be toggled on/off directly from the GUI interface

<!-- end of auto-generated comment: release notes by coderabbit.ai -->