### PR TITLE
docs: document audio effect headers

### DIFF
--- a/src/audio/effect.h
+++ b/src/audio/effect.h
@@ -21,7 +21,7 @@ class Effect {
 public:
     virtual ~Effect() = default;
 
-    // Process an interleaved mono buffer in place.
+    // Process a mono buffer in place.
     virtual void process(float* buffer, int num_samples) = 0;
 
     // Stereo processing. Default fans mono left channel to both outputs.

--- a/src/audio/effect.h
+++ b/src/audio/effect.h
@@ -5,6 +5,7 @@
 
 namespace Amplitron {
 
+// Runtime-editable effect parameter exposed to the UI and preset system.
 struct EffectParam {
     std::string name;
     float value;
@@ -15,10 +16,12 @@ struct EffectParam {
     std::string tooltip;
 };
 
+// Common interface for all mono/stereo audio effects in the pedal chain.
 class Effect {
 public:
     virtual ~Effect() = default;
 
+    // Process an interleaved mono buffer in place.
     virtual void process(float* buffer, int num_samples) = 0;
 
     // Stereo processing. Default fans mono left channel to both outputs.
@@ -28,10 +31,16 @@ public:
         std::memcpy(right, left, static_cast<size_t>(num_samples) * sizeof(float));
     }
 
+    // Update the processing sample rate before audio starts or after device changes.
     virtual void set_sample_rate(int sample_rate) { sample_rate_ = sample_rate; }
+
+    // Clear delay lines, envelopes, filters, and other effect state.
     virtual void reset() = 0;
 
+    // Display name used by the pedal board and preset serialization.
     virtual const char* name() const = 0;
+
+    // Mutable parameter list used by controls and automation.
     virtual std::vector<EffectParam>& params() = 0;
 
     void set_enabled(bool enabled) { enabled_ = enabled; }

--- a/src/audio/effects/amp_simulator.h
+++ b/src/audio/effects/amp_simulator.h
@@ -1,5 +1,7 @@
 #pragma once
 
+// Preamp and tone-stack models for classic guitar amplifier voicings.
+
 #include "audio/effect.h"
 #include "audio/dsp/biquad.h"
 

--- a/src/audio/effects/amp_simulator.h
+++ b/src/audio/effects/amp_simulator.h
@@ -1,6 +1,12 @@
 #pragma once
 
 // Preamp and tone-stack models for classic guitar amplifier voicings.
+// Signal model: y = L * sat(G * H_tone{x}, mix, asymmetry), where H_tone is
+// a low-shelf + peaking-mid + high-shelf biquad cascade. The factory models
+// cover Clean American / Fender Twin, British Crunch / Marshall JCM800,
+// High Gain Modern / Mesa Rectifier, and Jazz Warm / Roland JC-120. Dynamic
+// sag follows an envelope e[n] = a*x_abs[n] + (1-a)*e[n-1] and reduces gain
+// as the simulated supply is loaded.
 
 #include "audio/effect.h"
 #include "audio/dsp/biquad.h"

--- a/src/audio/effects/cabinet_sim.h
+++ b/src/audio/effects/cabinet_sim.h
@@ -1,5 +1,7 @@
 #pragma once
 
+// Lightweight speaker cabinet filtering for guitar amp output shaping.
+
 #include "audio/effect.h"
 #include "audio/dsp/biquad.h"
 

--- a/src/audio/effects/cabinet_sim.h
+++ b/src/audio/effects/cabinet_sim.h
@@ -1,6 +1,9 @@
 #pragma once
 
 // Lightweight speaker cabinet filtering for guitar amp output shaping.
+// Approximates speaker response as H(z)=H_hp(z) * H_peak(z) * H_lp(z): a low
+// cut removes rumble, a resonant biquad models cabinet/body emphasis, and a
+// low-pass rolloff attenuates harsh high-frequency content.
 
 #include "audio/effect.h"
 #include "audio/dsp/biquad.h"

--- a/src/audio/effects/chorus.h
+++ b/src/audio/effects/chorus.h
@@ -1,5 +1,7 @@
 #pragma once
 
+// Modulated delay effect that thickens the signal with chorus movement.
+
 #include "audio/effect.h"
 
 namespace Amplitron {

--- a/src/audio/effects/chorus.h
+++ b/src/audio/effects/chorus.h
@@ -1,6 +1,8 @@
 #pragma once
 
 // Modulated delay effect that thickens the signal with chorus movement.
+// The wet tap is y_w[n] = x[n - D(n)] with D(n)=D0 + A*sin(2*pi*f_lfo*n/Fs);
+// fractional delay reads use interpolation, then y[n]=(1-mix)*x[n]+mix*y_w[n].
 
 #include "audio/effect.h"
 

--- a/src/audio/effects/compressor.h
+++ b/src/audio/effects/compressor.h
@@ -1,5 +1,7 @@
 #pragma once
 
+// Dynamic range compressor for smoothing guitar input levels.
+
 #include "audio/effect.h"
 #include "audio/dsp/envelope_follower.h"
 

--- a/src/audio/effects/compressor.h
+++ b/src/audio/effects/compressor.h
@@ -1,6 +1,9 @@
 #pragma once
 
 // Dynamic range compressor for smoothing guitar input levels.
+// An envelope follower estimates level e[n]; above threshold T, gain follows
+// g_db = T + (level_db - T)/ratio - level_db, with attack/release smoothing
+// applied before multiplying y[n] = x[n] * 10^(g_db/20).
 
 #include "audio/effect.h"
 #include "audio/dsp/envelope_follower.h"

--- a/src/audio/effects/delay.h
+++ b/src/audio/effects/delay.h
@@ -1,5 +1,7 @@
 #pragma once
 
+// Tempo-independent delay line with feedback and wet/dry control.
+
 #include "audio/effect.h"
 #include "audio/dsp/biquad.h"
 

--- a/src/audio/effects/delay.h
+++ b/src/audio/effects/delay.h
@@ -1,6 +1,9 @@
 #pragma once
 
-// Tempo-independent delay line with feedback and wet/dry control.
+// Tempo-independent ring-buffer delay line with feedback and wet/dry control.
+// The circular buffer reads d samples behind the write head and writes
+// x[n] + feedback*y_delay[n]; output is y[n]=(1-mix)*x[n]+mix*y_delay[n], with
+// a one-pole tone filter shaping repeated echoes.
 
 #include "audio/effect.h"
 #include "audio/dsp/biquad.h"

--- a/src/audio/effects/distortion.h
+++ b/src/audio/effects/distortion.h
@@ -1,5 +1,7 @@
 #pragma once
 
+// Hard-clipping distortion effect with tone shaping.
+
 #include "audio/effect.h"
 #include "audio/dsp/biquad.h"
 

--- a/src/audio/effects/distortion.h
+++ b/src/audio/effects/distortion.h
@@ -9,10 +9,15 @@ namespace Amplitron {
 
 class Distortion : public Effect {
 public:
+    // Create a distortion effect with drive, tone, and output gain controls.
     Distortion();
+    // Apply the distortion curve and filtering to a mono audio buffer.
     void process(float* buffer, int num_samples) override;
+    // Clear any filter state held by the effect.
     void reset() override;
+    // Return the display name for this effect.
     const char* name() const override { return "Distortion"; }
+    // Return editable parameters exposed by this effect.
     std::vector<EffectParam>& params() override { return params_; }
 
 private:

--- a/src/audio/effects/distortion.h
+++ b/src/audio/effects/distortion.h
@@ -1,6 +1,9 @@
 #pragma once
 
 // Hard-clipping distortion effect with tone shaping.
+// The driven sample u=drive*x[n] is clipped with y=clamp(u, -clip, clip), then
+// filtered by the tone stage and level-scaled; this creates odd harmonics as
+// the transfer function flattens near the clipping threshold.
 
 #include "audio/effect.h"
 #include "audio/dsp/biquad.h"

--- a/src/audio/effects/equalizer.h
+++ b/src/audio/effects/equalizer.h
@@ -1,5 +1,7 @@
 #pragma once
 
+// Multi-band equalizer for tone correction and pedal-chain shaping.
+
 #include "audio/effect.h"
 #include "audio/dsp/biquad.h"
 

--- a/src/audio/effects/equalizer.h
+++ b/src/audio/effects/equalizer.h
@@ -1,6 +1,8 @@
 #pragma once
 
-// Multi-band equalizer for tone correction and pedal-chain shaping.
+// 3-band parametric equalizer for tone correction and pedal-chain shaping.
+// The Equalizer cascades active biquads H(z)=H_lowShelf(z)*H_peakMid(z)*H_highShelf(z),
+// giving independent low-shelf, peaking-mid, and high-shelf gain control.
 
 #include "audio/effect.h"
 #include "audio/dsp/biquad.h"

--- a/src/audio/effects/flanger.h
+++ b/src/audio/effects/flanger.h
@@ -1,5 +1,7 @@
 #pragma once
 
+// Short modulated delay effect for comb-filter sweep sounds.
+
 #include "audio/effect.h"
 
 namespace Amplitron {

--- a/src/audio/effects/flanger.h
+++ b/src/audio/effects/flanger.h
@@ -1,6 +1,9 @@
 #pragma once
 
 // Short modulated delay effect for comb-filter sweep sounds.
+// Uses y[n]=x[n]+feedback*y[n-D(n)] mixed with a wet tap x[n-D(n)], where
+// D(n)=D0 + A*sin(2*pi*f_lfo*n/Fs); the varying delay moves comb notches at
+// frequencies approximately k*Fs/D(n).
 
 #include "audio/effect.h"
 

--- a/src/audio/effects/ir_cabinet.h
+++ b/src/audio/effects/ir_cabinet.h
@@ -1,5 +1,7 @@
 #pragma once
 
+// Impulse-response based cabinet simulation for recorded speaker tones.
+
 #include "audio/effect.h"
 #include "audio/dsp/convolution_engine.h"
 #include <atomic>

--- a/src/audio/effects/ir_cabinet.h
+++ b/src/audio/effects/ir_cabinet.h
@@ -1,6 +1,9 @@
 #pragma once
 
 // Impulse-response based cabinet simulation for recorded speaker tones.
+// Implements convolution y[n] = sum_k h[k] * x[n-k], where h[k] is the loaded
+// speaker/cabinet impulse response; wet/dry mix blends the convolved cabinet
+// tone with the direct signal.
 
 #include "audio/effect.h"
 #include "audio/dsp/convolution_engine.h"

--- a/src/audio/effects/noise_gate.h
+++ b/src/audio/effects/noise_gate.h
@@ -1,5 +1,7 @@
 #pragma once
 
+// Noise gate that attenuates low-level input between notes.
+
 #include "audio/effect.h"
 #include "audio/dsp/envelope_follower.h"
 

--- a/src/audio/effects/noise_gate.h
+++ b/src/audio/effects/noise_gate.h
@@ -1,6 +1,9 @@
 #pragma once
 
 // Noise gate that attenuates low-level input between notes.
+// An envelope follower tracks amplitude e[n]; when e[n] falls below threshold
+// T, gain approaches 0 with release smoothing, and when e[n]>=T it approaches
+// 1 with attack smoothing, preventing abrupt chopping.
 
 #include "audio/effect.h"
 #include "audio/dsp/envelope_follower.h"

--- a/src/audio/effects/octaver.h
+++ b/src/audio/effects/octaver.h
@@ -1,5 +1,7 @@
 #pragma once
 
+// Octave generator for sub-octave and upper-octave guitar tones.
+
 #include "audio/effect.h"
 
 namespace Amplitron {

--- a/src/audio/effects/octaver.h
+++ b/src/audio/effects/octaver.h
@@ -1,6 +1,9 @@
 #pragma once
 
 // Octave generator for sub-octave and upper-octave guitar tones.
+// Sub-octave generation derives a period-doubled component from zero-crossing
+// state, while the upper octave emphasizes rectified/nonlinear content; output
+// blends dry, sub, and upper components by their mix gains.
 
 #include "audio/effect.h"
 

--- a/src/audio/effects/overdrive.h
+++ b/src/audio/effects/overdrive.h
@@ -1,5 +1,7 @@
 #pragma once
 
+// Soft-clipping overdrive effect for tube-style saturation.
+
 #include "audio/effect.h"
 #include "audio/dsp/biquad.h"
 

--- a/src/audio/effects/overdrive.h
+++ b/src/audio/effects/overdrive.h
@@ -1,6 +1,9 @@
 #pragma once
 
 // Soft-clipping overdrive effect for tube-style saturation.
+// The transfer curve uses smooth saturation such as y=tanh(drive*x[n]) or an
+// equivalent soft clip, preserving small-signal dynamics while compressing
+// peaks before tone filtering and output level scaling.
 
 #include "audio/effect.h"
 #include "audio/dsp/biquad.h"

--- a/src/audio/effects/phaser.h
+++ b/src/audio/effects/phaser.h
@@ -1,5 +1,7 @@
 #pragma once
 
+// Cascaded all-pass phaser with LFO modulation.
+
 #include "audio/effect.h"
 #include <array>
 

--- a/src/audio/effects/phaser.h
+++ b/src/audio/effects/phaser.h
@@ -1,6 +1,9 @@
 #pragma once
 
 // Cascaded all-pass phaser with LFO modulation.
+// Each all-pass stage has near-unity magnitude and phase shift A(z); mixing
+// dry + wet creates notches where phase cancellation occurs. The LFO modulates
+// the all-pass coefficient so notch frequencies sweep over time.
 
 #include "audio/effect.h"
 #include <array>

--- a/src/audio/effects/pitch_shifter.h
+++ b/src/audio/effects/pitch_shifter.h
@@ -1,5 +1,7 @@
 #pragma once
 
+// Pitch shifting effect for semitone-based transposition.
+
 #include "audio/effect.h"
 #include <vector>
 

--- a/src/audio/effects/pitch_shifter.h
+++ b/src/audio/effects/pitch_shifter.h
@@ -1,6 +1,9 @@
 #pragma once
 
 // Pitch shifting effect for semitone-based transposition.
+// The shift ratio is r = 2^(semitones/12); the processor reads from a delay
+// line/resampling window at rate r and crossfades windows to reduce clicks,
+// producing y[n] from time-scaled input samples.
 
 #include "audio/effect.h"
 #include <vector>

--- a/src/audio/effects/reverb.h
+++ b/src/audio/effects/reverb.h
@@ -1,5 +1,7 @@
 #pragma once
 
+// Algorithmic reverb for adding room and tail reflections.
+
 #include "audio/effect.h"
 
 namespace Amplitron {

--- a/src/audio/effects/reverb.h
+++ b/src/audio/effects/reverb.h
@@ -1,6 +1,9 @@
 #pragma once
 
 // Algorithmic reverb for adding room and tail reflections.
+// Uses a Schroeder-style network: parallel feedback combs y_i[n]=x[n]+g_i*y_i[n-d_i]
+// build the decay tail, followed by all-pass filters that diffuse echoes while
+// keeping magnitude roughly flat.
 
 #include "audio/effect.h"
 

--- a/src/audio/effects/tuner.h
+++ b/src/audio/effects/tuner.h
@@ -1,5 +1,7 @@
 #pragma once
 
+// Chromatic tuner based on pitch detection from the input signal.
+
 #include "audio/effect.h"
 #include <atomic>
 

--- a/src/audio/effects/tuner.h
+++ b/src/audio/effects/tuner.h
@@ -1,6 +1,9 @@
 #pragma once
 
 // Chromatic tuner based on pitch detection from the input signal.
+// Uses the YIN difference d(tau)=sum_j(x[j]-x[j+tau])^2 and cumulative mean
+// normalized difference to estimate period tau; frequency is Fs/tau and cents
+// error is 1200*log2(freq / nearest_note_freq).
 
 #include "audio/effect.h"
 #include <atomic>

--- a/src/audio/effects/wah.h
+++ b/src/audio/effects/wah.h
@@ -1,5 +1,7 @@
 #pragma once
 
+// Wah filter with manual and envelope-following sweep modes.
+
 #include "audio/effect.h"
 #include "audio/dsp/envelope_follower.h"
 

--- a/src/audio/effects/wah.h
+++ b/src/audio/effects/wah.h
@@ -1,6 +1,9 @@
 #pragma once
 
 // Wah filter with manual and envelope-following sweep modes.
+// A resonant state-variable band-pass filter sweeps center frequency f_c; in
+// auto mode f_c follows an envelope e[n], while manual mode maps pedal position
+// directly. Resonance/Q controls bandwidth around f_c.
 
 #include "audio/effect.h"
 #include "audio/dsp/envelope_follower.h"


### PR DESCRIPTION
## Summary

Adds short comments to the shared effect interface and the audio effect headers.

This keeps the change focused on contributor-facing documentation and does not change DSP behavior.

## Testing

- `git diff --check`

I did not run a full local build because this is a comment-only change and the native audio dependencies are not installed in this environment.

Fixes #68


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added descriptive comments across all audio effect modules (amp simulator, cabinet, chorus, compressor, delay, distortion, equalizer, flanger, IR cabinet, noise gate, octaver, overdrive, phaser, pitch shifter, reverb, tuner, wah) to improve clarity and maintainability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sudip-mondal-2002/Amplitron/pull/75)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->