### PR TITLE
Feat: add spectrum analyzer state handling to PedalWidget

### DIFF
--- a/src/gui/pedal_widget.h
+++ b/src/gui/pedal_widget.h
@@ -2,6 +2,7 @@
 
 #include "common.h"
 #include "audio/effect.h"
+#include "gui/spectrum_analyzer.h"
 #include <imgui.h>
 
 namespace Amplitron {
@@ -88,6 +89,9 @@ private:
 
     ImVec4 pedal_color_;  ///< Pedal body color derived from effect type.
     ImVec4 led_color_;    ///< LED / accent color derived from effect type.
+
+    spectrumAnalyser spectrum_analyzer_;
+    bool show_analyzer_ = false;
 
     /** @brief Look up pedal_color_ and led_color_ from the theme table. */
     void assign_colors();


### PR DESCRIPTION
Added SpectrumAnalyzer integration fields to Pedal widget.

Changes made:

- Included gui/spectrum_analyzer.h in pedal_widget.h
- Added Spectrum Analyzer instance to each pedal widget
- Added show_spectrum_ toggle state for per-pedal spectrum overlay visibility

This prepares the pedal widget for realtime spectrum overlay rendering and analyzer state management.
Purpose
This is part of the implementation for the per-pedal spectrum analyser feature requested in Issue #73/#105.
The update prepares each pedal to independently manage analyzer visibility and spectrum rendering state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Spectrum analyzer now integrated into the pedal widget with toggleable visibility controls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sudip-mondal-2002/Amplitron/pull/129?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->