### PR TITLE
Add: BPM text input synced to Delay and Chorus DSP

### DIFF
--- a/src/audio/audio_engine.h
+++ b/src/audio/audio_engine.h
@@ -212,6 +212,10 @@ public:
      */
     void set_output_gain(float gain);
 
+    //transport controls
+    float get_bpm() const;
+    void set_bpm(float bpm);
+    
     /** @brief Return the current input gain (atomic relaxed read). */
     float get_input_gain() const { return input_gain_.load(std::memory_order_relaxed); }
 
@@ -291,7 +295,8 @@ private:
     int output_device_ = -1;
     int sample_rate_ = DEFAULT_SAMPLE_RATE;
     int buffer_size_ = DEFAULT_BUFFER_SIZE;
-
+    //global transport
+    std::atomic<float> global_bpm_{120.0f};
     std::atomic<float> input_gain_{1.0f};
     std::atomic<float> output_gain_{0.8f};
 

--- a/src/audio/audio_engine.h
+++ b/src/audio/audio_engine.h
@@ -212,9 +212,6 @@ public:
      */
     void set_output_gain(float gain);
 
-    //transport controls
-    float get_bpm() const;
-    void set_bpm(float bpm);
     
     /** @brief Return the current input gain (atomic relaxed read). */
     float get_input_gain() const { return input_gain_.load(std::memory_order_relaxed); }
@@ -314,7 +311,6 @@ private:
     int sample_rate_ = DEFAULT_SAMPLE_RATE;
     int buffer_size_ = DEFAULT_BUFFER_SIZE;
     //global transport
-    std::atomic<float> global_bpm_{120.0f};
     std::atomic<float> input_gain_{1.0f};
     std::atomic<float> output_gain_{0.8f};
     std::atomic<bool> metronome_enabled_state_{false};

--- a/src/audio/audio_engine_api.cpp
+++ b/src/audio/audio_engine_api.cpp
@@ -86,16 +86,10 @@ float AudioEngine::get_bpm() const{
 }
 
 void AudioEngine::set_bpm(float bpm){
+    if (!std::isfinite(bpm) || bpm <= 0.0f) return;
+    bpm = std::clamp(bpm, 20.0f, 300.0f);
     //save new tempo
     global_bpm_.store(bpm, std::memory_order_relaxed);
-    //lock pedalboard during update
-    std::lock_guard<std::mutex> lock(effect_mutex_);
-    //broadcast_tempo
-    for(auto& fx : effects_){
-        if(fx){
-            fx->set_transport_state(bpm);
-        }
-    }
 }
 
 } // namespace Amplitron

--- a/src/audio/audio_engine_api.cpp
+++ b/src/audio/audio_engine_api.cpp
@@ -96,15 +96,4 @@ bool AudioEngine::copy_analyzer_snapshot(float* input_dest,
     return true;
 }
 
-float AudioEngine::get_bpm() const{
-    return global_bpm_.load(std::memory_order_relaxed);
-}
-
-void AudioEngine::set_bpm(float bpm){
-    if (!std::isfinite(bpm) || bpm <= 0.0f) return;
-    bpm = std::clamp(bpm, 20.0f, 300.0f);
-    //save new tempo
-    global_bpm_.store(bpm, std::memory_order_relaxed);
-}
-
 } // namespace Amplitron

--- a/src/audio/audio_engine_api.cpp
+++ b/src/audio/audio_engine_api.cpp
@@ -81,4 +81,21 @@ bool AudioEngine::copy_analyzer_snapshot(float* input_dest,
     return true;
 }
 
+float AudioEngine::get_bpm() const{
+    return global_bpm_.load(std::memory_order_relaxed);
+}
+
+void AudioEngine::set_bpm(float bpm){
+    //save new tempo
+    global_bpm_.store(bpm, std::memory_order_relaxed);
+    //lock pedalboard during update
+    std::lock_guard<std::mutex> lock(effect_mutex_);
+    //broadcast_tempo
+    for(auto& fx : effects_){
+        if(fx){
+            fx->set_transport_state(bpm);
+        }
+    }
+}
+
 } // namespace Amplitron

--- a/src/audio/audio_engine_process.cpp
+++ b/src/audio/audio_engine_process.cpp
@@ -129,7 +129,7 @@ void AudioEngine::process_audio(const float* input, float* output, int frame_cou
                     static_cast<size_t>(frame_count) * sizeof(float));
     }
     //tempo/bpm broadcast
-    float current_bpm = global_bpm_.load(std::memory_order_relaxed);
+    float current_bpm = static_cast<float>(metronome_bpm_);
     for (auto& fx : audio_shadow_effects_) {
         if (fx) {
             fx->set_transport_state(current_bpm);

--- a/src/audio/audio_engine_process.cpp
+++ b/src/audio/audio_engine_process.cpp
@@ -61,6 +61,14 @@ void AudioEngine::process_audio(const float* input, float* output, int frame_cou
         std::memcpy(process_buffer_right_.data(), process_buffer_.data(),
                     static_cast<size_t>(frame_count) * sizeof(float));
     }
+    //tempo/bpm broadcast
+    float current_bpm = global_bpm_.load(std::memory_order_relaxed);
+    for (auto& fx : audio_shadow_effects_) {
+        if (fx) {
+            fx->set_transport_state(current_bpm);
+        }
+    }
+    
     for (auto& fx : audio_shadow_effects_) {
         if (fx->is_enabled()) {
             fx->process_stereo(process_buffer_.data(),

--- a/src/audio/effect.h
+++ b/src/audio/effect.h
@@ -37,6 +37,9 @@ public:
     // Clear delay lines, envelopes, filters, and other effect state.
     virtual void reset() = 0;
 
+    // Tempo broadcast receiver.
+    virtual void set_transport_state(float /*bpm*/) {}
+
     // Display name used by the pedal board and preset serialization.
     virtual const char* name() const = 0;
 

--- a/src/audio/effects/chorus.cpp
+++ b/src/audio/effects/chorus.cpp
@@ -67,10 +67,12 @@ void Chorus::process_stereo(float* left, float* right, int num_samples) {
     if (!enabled_) {
         return;
     }
-
-    const float rate       = params_[0].value;
-    const float depth_ms   = params_[1].value;
-    const float level      = params_[2].value;
+    const float alpha = 1.0f - std::exp(-1.0f / (sample_rate_ * 0.020f));
+    smoothed_rate_ += alpha * (params_[0].value - smoothed_rate_);
+    float rate = smoothed_rate_;
+    float depth_ms = params_[1].value;
+    float level = params_[2].value;
+    
     const float depth_samp = depth_ms * 0.001f * sample_rate_;
     const float lfo_inc    = rate / sample_rate_;
 

--- a/src/audio/effects/chorus.cpp
+++ b/src/audio/effects/chorus.cpp
@@ -105,6 +105,15 @@ void Chorus::process_stereo(float* left, float* right, int num_samples) {
     }
 }
 
+void Chorus::set_transport_state(float bpm){
+    if(bpm == last_bpm_) return;
+    last_bpm_ = bpm;
+    //BPM to Hz
+    float target_rate_hz = bpm / 60.0f;
+    //set knob
+    params_[0].value = clamp(target_rate_hz, params_[0].min_val, params_[0].max_val);
+}
+
 void Chorus::reset() {
     std::fill(delay_buffer_.begin(), delay_buffer_.end(), 0.0f);
     write_pos_ = 0;

--- a/src/audio/effects/chorus.cpp
+++ b/src/audio/effects/chorus.cpp
@@ -24,7 +24,9 @@ void Chorus::set_sample_rate(int sample_rate) {
 void Chorus::process(float* buffer, int num_samples) {
     if (!enabled_) return;
 
-    float rate = params_[0].value;
+    const float alpha = 1.0f - std::exp(-1.0f / (sample_rate_ * 0.020f));
+    smoothed_rate_ += alpha * (params_[0].value - smoothed_rate_);
+    float rate = smoothed_rate_;
     float depth_ms = params_[1].value;
     float level = params_[2].value;
 
@@ -106,6 +108,7 @@ void Chorus::process_stereo(float* left, float* right, int num_samples) {
 }
 
 void Chorus::set_transport_state(float bpm){
+    if(!std::isfinite(bpm) || bpm <= 0.0f)return;
     if(bpm == last_bpm_) return;
     last_bpm_ = bpm;
     //BPM to Hz

--- a/src/audio/effects/chorus.h
+++ b/src/audio/effects/chorus.h
@@ -26,6 +26,7 @@ private:
     float lfo_phase_ = 0.0f;
     int max_delay_samples_ = 0;
     float last_bpm_=0.0f; //shortcut if bpm not changed.
+    float smoothed_rate_ = 1.5f;
 };
 
 } // namespace Amplitron

--- a/src/audio/effects/chorus.h
+++ b/src/audio/effects/chorus.h
@@ -14,6 +14,7 @@ public:
     void process(float* buffer, int num_samples) override;
     void process_stereo(float* left, float* right, int num_samples) override;
     void set_sample_rate(int sample_rate) override;
+    void set_transport_state(float bpm) override;
     void reset() override;
     const char* name() const override { return "Chorus"; }
     std::vector<EffectParam>& params() override { return params_; }
@@ -24,6 +25,7 @@ private:
     int write_pos_ = 0;
     float lfo_phase_ = 0.0f;
     int max_delay_samples_ = 0;
+    float last_bpm_=0.0f; //shortcut if bpm not changed.
 };
 
 } // namespace Amplitron

--- a/src/audio/effects/delay.cpp
+++ b/src/audio/effects/delay.cpp
@@ -68,6 +68,7 @@ void Delay::reset() {
 }
 
 void Delay::set_transport_state(float bpm){
+    if(bpm <= 0.0f || !std::isfinite(bpm)) return;
     if(bpm == last_bpm_) return;
     last_bpm_=bpm;
 

--- a/src/audio/effects/delay.cpp
+++ b/src/audio/effects/delay.cpp
@@ -67,4 +67,29 @@ void Delay::reset() {
     tone_lp_.reset();
 }
 
+void Delay::set_transport_state(float bpm){
+    if(bpm == last_bpm_) return;
+    last_bpm_=bpm;
+
+    //Quarter-note duration
+    float quarter_note_ms = 60000.0f / bpm;
+    //Check current knob
+    float current_knob_time = params_[0].value;
+    //Distance to nearest subdivisions
+    float diff_quarter = std::fabs(current_knob_time - quarter_note_ms);
+    float diff_eighth = std::fabs(current_knob_time - (quarter_note_ms * 0.5f));
+    float diff_sixteenth = std::fabs(current_knob_time - (quarter_note_ms * 0.25f));
+    //Check closest
+    float target_time = quarter_note_ms; //default to 1/4 note
+    if(diff_eighth < diff_quarter && diff_eighth < diff_sixteenth){
+        target_time = quarter_note_ms * 0.5f; // 1/8 note
+    }
+    else if(diff_sixteenth < diff_quarter && diff_sixteenth < diff_eighth){
+        target_time = quarter_note_ms * 0.25f; // 1/16 note
+    }
+    
+    //Set knob
+    params_[0].value = clamp(target_time, params_[0].min_val, params_[0].max_val);
+}
+
 } // namespace Amplitron

--- a/src/audio/effects/delay.h
+++ b/src/audio/effects/delay.h
@@ -15,6 +15,7 @@ public:
     Delay();
     void process(float* buffer, int num_samples) override;
     void set_sample_rate(int sample_rate) override;
+    void set_transport_state(float bpm) override;
     void reset() override;
     const char* name() const override { return "Delay"; }
     std::vector<EffectParam>& params() override { return params_; }
@@ -31,6 +32,9 @@ private:
     float smoothed_feedback_ = 0.4f;
     float smoothed_tone_ = 0.7f;
     float smoothed_level_ = 0.5f;
+
+    //shortcut if bpm hasn't changed
+    float last_bpm_ = 0.0f;
 };
 
 } // namespace Amplitron

--- a/src/gui/gui_snapshots.cpp
+++ b/src/gui/gui_snapshots.cpp
@@ -153,21 +153,6 @@ void GuiSnapshots::render() {
             "  Left-click to recall  |  Right-click to save / clear  |  Ctrl+1-4 to recall");
     }
 
-    //Transport and Tempo controls
-    ImGui::SameLine();
-    ImGui::TextUnformatted(" | "); // A clean visual divider
-    ImGui::SameLine();
-    // 2. Tempo Number Field
-    ImGui::SetNextItemWidth(42.5f);
-    float current_bpm = engine_.get_bpm();
-    if (ImGui::InputFloat("BPM", &current_bpm, 0.0f, 0.0f, "%.1f")) {
-        // Clamp the numbers to a safe musical range (40 to 250 BPM)
-        current_bpm = std::clamp(current_bpm, 40.0f, 250.0f);
-        engine_.set_bpm(current_bpm);//set tempo
-        std::printf("Tempo adjusted to: %.1f BPM\n", current_bpm);
-
-    }
-
     ImGui::EndChild();
 }
 } // namespace Amplitron

--- a/src/gui/gui_snapshots.cpp
+++ b/src/gui/gui_snapshots.cpp
@@ -140,7 +140,7 @@ void GuiSnapshots::render() {
             ImGui::EndPopup();
         }
     }
-
+    
     ImGui::SameLine();
 
     // Status message or hint text
@@ -151,6 +151,21 @@ void GuiSnapshots::render() {
     } else {
         ImGui::TextColored(Theme::TextDim(),
             "  Left-click to recall  |  Right-click to save / clear  |  Ctrl+1-4 to recall");
+    }
+
+    //Transport and Tempo controls
+    ImGui::SameLine();
+    ImGui::TextUnformatted(" | "); // A clean visual divider
+    ImGui::SameLine();
+    // 2. Tempo Number Field
+    ImGui::SetNextItemWidth(42.5f);
+    float current_bpm = engine_.get_bpm();
+    if (ImGui::InputFloat("BPM", &current_bpm, 0.0f, 0.0f, "%.1f")) {
+        // Clamp the numbers to a safe musical range (40 to 250 BPM)
+        current_bpm = std::clamp(current_bpm, 40.0f, 250.0f);
+        engine_.set_bpm(current_bpm);//set tempo
+        std::printf("Tempo adjusted to: %.1f BPM\n", current_bpm);
+
     }
 
     ImGui::EndChild();

--- a/tests/test_effects.cpp
+++ b/tests/test_effects.cpp
@@ -1217,3 +1217,35 @@ TEST(pitch_shifter_with_mix_and_shift_differs_from_dry) {
     // The shifted frequency should be dominant (higher magnitude than original)
     ASSERT_GT(mag_shifted, mag_440 * 0.5f);
 }
+
+// ============================================================
+// Tempo / BPM Syncing Tests
+// ============================================================
+
+TEST(delay_calculates_correct_time_from_bpm) {
+    Delay dl;
+    dl.set_sample_rate(48000);
+    dl.reset();
+
+    // To test quarter-note snapping at 120 BPM (500ms), we first set the
+    // knob close to 500ms so the subdivision logic picks the quarter note.
+    dl.params()[0].value = 490.0f; 
+    
+    // Trigger the BPM sync
+    dl.set_transport_state(120.0f); 
+
+    // At 120 BPM, a quarter note is 500.0 ms (60000 / 120)
+    ASSERT_NEAR(dl.params()[0].value, 500.0f, 0.01f);
+}
+
+TEST(chorus_calculates_correct_rate_from_bpm) {
+    Chorus ch;
+    ch.set_sample_rate(48000);
+    ch.reset();
+
+    // Trigger the BPM sync
+    ch.set_transport_state(120.0f);
+
+    // At 120 BPM, the LFO rate should be 2.0 Hz (120 / 60)
+    ASSERT_NEAR(ch.params()[0].value, 2.0f, 0.01f);
+}


### PR DESCRIPTION
This is the first half of the tempo feature! The manual input field is wired to the audio engine, and the time and rate knobs in the Delay & Chorus pedals update according to the input. (I will tackle the actual TAP button math in a separate PR later).

## Related Issue

Fixes #65

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor / code cleanup
- [ ] 📝 Documentation
- [ ] ✅ Tests
- [ ] 🔧 Build / CI / Configuration

## How Was This Tested?

- Platform(s) tested on: Fedora Linux
- Test command run: `./amplitron-tests`
- Manual test steps: Spawned Delay and Chorus pedals in the UI, adjusted the BPM via the new text input, and visually verified the respective time/rate knobs automatically calculated and adjusted to match the new tempo.

## Checklist

- [x] Code compiles and builds successfully on my platform
- [x] All existing tests pass (`./amplitron-tests`)
- [ ] New tests added for new functionality (if applicable)
- [ ] Documentation updated (README, code comments) if applicable
- [x] No blocking calls on the audio thread (no `std::mutex::lock()` on the hot path)
- [x] Tested on: Fedora Linux

## Screenshots / Demo
[Screencast From 2026-05-19 16-16-17.webm](https://github.com/user-attachments/assets/6a372157-b10e-42a4-a35a-dee171849f60)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added BPM control to the audio engine with getter and setter methods.
  * Chorus effect now syncs its modulation rate to the engine's BPM.
  * Delay effect now quantizes delay time to note durations based on BPM.

* **Tests**
  * Added tempo and BPM synchronization validation tests.

* **Style**
  * Minor UI layout adjustment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sudip-mondal-2002/Amplitron/pull/130?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->