### PR TITLE
ci: Use artifacts to pass coverage data between jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
 
       - name: Generate Coverage Report
         run: |
-          lcov --capture --directory build --output-file coverage.info --ignore-errors mismatch,gcov
+          lcov --capture --directory build --output-file coverage.info --ignore-errors mismatch,gcov,source
           lcov --remove coverage.info \
             '/usr/*' \
             '*/external/*' \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,11 +64,26 @@ jobs:
       - name: Build
         run: |
           mkdir -p build && cd build
-          cmake -DCMAKE_BUILD_TYPE=Release -DAMPLITRON_VERSION="${{ steps.version.outputs.version }}" ..
+          cmake -DCMAKE_BUILD_TYPE=Debug \
+            -DAMPLITRON_VERSION="${{ steps.version.outputs.version }}" \
+            -DCMAKE_C_FLAGS="--coverage -O0 -g" \
+            -DCMAKE_CXX_FLAGS="--coverage -O0 -g" \
+            -DCMAKE_EXE_LINKER_FLAGS="--coverage" \
+            ..
           make -j$(nproc)
 
       - name: Run Tests
         run: cd build && ./amplitron-tests
+
+      - name: Package Build Data for Coverage
+        run: tar -czf build-coverage.tar.gz build/
+
+      - name: Upload Build Artifact for Coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-coverage
+          path: build-coverage.tar.gz
+          retention-days: 1
 
       - name: Upload Build
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
@@ -80,53 +95,26 @@ jobs:
 
   coverage-linux:
     name: Coverage Report on Linux
+    needs: test-linux
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - name: Install Dependencies
+      - name: Install lcov
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends \
-            build-essential cmake lcov \
-            libportaudio2 portaudio19-dev \
-            libsdl2-dev libgl1-mesa-dev libglu1-mesa-dev \
-            librtmidi-dev
+          sudo apt-get install -y --no-install-recommends lcov
 
-      - name: Setup External Dependencies
-        run: |
-          mkdir -p external external/kiss_fft
-          git clone --depth 1 --branch v1.90.1 https://github.com/ocornut/imgui.git external/imgui &
-          curl -fsSL -o external/nanosvg.h https://raw.githubusercontent.com/memononen/nanosvg/master/src/nanosvg.h &
-          curl -fsSL -o external/nanosvgrast.h https://raw.githubusercontent.com/memononen/nanosvg/master/src/nanosvgrast.h &
-          curl -fsSL -o external/dr_wav.h https://raw.githubusercontent.com/mackron/dr_libs/master/dr_wav.h &
-          curl -fsSL -o external/kiss_fft/kiss_fft.h https://raw.githubusercontent.com/mborgerding/kissfft/master/kiss_fft.h &
-          curl -fsSL -o external/kiss_fft/kiss_fft.c https://raw.githubusercontent.com/mborgerding/kissfft/master/kiss_fft.c &
-          curl -fsSL -o external/kiss_fft/_kiss_fft_guts.h https://raw.githubusercontent.com/mborgerding/kissfft/master/_kiss_fft_guts.h &
-          curl -fsSL -o external/kiss_fft/kiss_fft_log.h https://raw.githubusercontent.com/mborgerding/kissfft/master/kiss_fft_log.h &
-          wait
+      - name: Download Build Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: build-coverage
+          path: .
 
-      - name: Generate Version
-        id: version
-        run: |
-          COUNT=$(git rev-list --count HEAD)
-          echo "version=0.1.${COUNT}" >> $GITHUB_OUTPUT
-
-      - name: Build with Coverage Flags
-        run: |
-          mkdir -p build && cd build
-          cmake -DCMAKE_BUILD_TYPE=Debug \
-            -DAMPLITRON_VERSION="${{ steps.version.outputs.version }}" \
-            -DCMAKE_C_FLAGS="--coverage -O0 -g" \
-            -DCMAKE_CXX_FLAGS="--coverage -O0 -g" \
-            -DCMAKE_EXE_LINKER_FLAGS="--coverage" \
-            ..
-          make -j$(nproc)
-
-      - name: Run Tests
-        run: cd build && ./amplitron-tests
+      - name: Extract Build Data
+        run: tar -xzf build-coverage.tar.gz
 
       - name: Generate Coverage Report
         run: |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored CI/CD pipeline to optimize code coverage collection. Tests now build with coverage instrumentation, and the coverage analysis job reuses build artifacts instead of performing redundant rebuilds, improving overall pipeline efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sudip-mondal-2002/Amplitron/pull/179?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->