### PR TITLE
feat: implement missing SPSCQueue, Effect base class, and EffectFactory features with unit tests

### DIFF
--- a/src/audio/effect.h
+++ b/src/audio/effect.h
@@ -4,6 +4,7 @@
 #include <cstring>
 #include <vector>
 #include <string>
+#include <memory>
 #include <nlohmann/json.hpp>
 
 namespace Amplitron {
@@ -54,6 +55,38 @@ public:
 
     void set_mix(float mix) { mix_ = clamp(mix, 0.0f, 1.0f); }
     float get_mix() const { return mix_; }
+
+    virtual std::shared_ptr<Effect> clone() const;
+
+    std::vector<std::string> get_param_names() {
+        std::vector<std::string> names;
+        for (const auto& p : params()) {
+            names.push_back(p.name);
+        }
+        return names;
+    }
+
+    float get_param_value(const std::string& name) {
+        for (const auto& p : params()) {
+            if (p.name == name) {
+                return p.value;
+            }
+        }
+        return 0.0f;
+    }
+
+    void set_param_by_name(const std::string& name, float value) {
+        for (auto& p : params()) {
+            if (p.name == name) {
+                p.value = clamp(value, p.min_val, p.max_val);
+                return;
+            }
+        }
+    }
+
+    virtual const char* get_display_name() const {
+        return name();
+    }
 
     // --- AUTOMATED SERIALIZATION LOGIC ---
     // These methods automatically handle saving/loading for any effect 

--- a/src/audio/effect.h
+++ b/src/audio/effect.h
@@ -47,6 +47,8 @@ public:
     // Display name used by the pedal board and preset serialization.
     virtual const char* name() const = 0;
 
+    virtual const char* type_id() const { return name(); }
+
     // Mutable parameter list used by controls and automation.
     virtual std::vector<EffectParam>& params() = 0;
 

--- a/src/audio/effect_factory.h
+++ b/src/audio/effect_factory.h
@@ -46,6 +46,14 @@ public:
         return types;
     }
 
+    std::shared_ptr<Effect> create_from_type(const std::string& type_name) const {
+        return create(type_name);
+    }
+
+    std::vector<std::string> get_all_type_names() const {
+        return registered_types();
+    }
+
 private:
     EffectFactory() = default;
     std::unordered_map<std::string, Creator> creators_;
@@ -64,5 +72,15 @@ struct EffectRegistrar {
         });
     }
 };
+
+inline std::shared_ptr<Effect> Effect::clone() const {
+    auto new_effect = EffectFactory::instance().create(name());
+    if (new_effect) {
+        new_effect->set_params(get_params());
+        new_effect->set_enabled(enabled_);
+        new_effect->set_mix(mix_);
+    }
+    return new_effect;
+}
 
 } // namespace Amplitron

--- a/src/audio/effect_factory.h
+++ b/src/audio/effect_factory.h
@@ -74,7 +74,7 @@ struct EffectRegistrar {
 };
 
 inline std::shared_ptr<Effect> Effect::clone() const {
-    auto new_effect = EffectFactory::instance().create(name());
+    auto new_effect = EffectFactory::instance().create(type_id());
     if (new_effect) {
         new_effect->set_params(get_params());
         new_effect->set_enabled(enabled_);

--- a/src/audio/effects/amp_simulator.h
+++ b/src/audio/effects/amp_simulator.h
@@ -68,6 +68,7 @@ public:
     void set_sample_rate(int sample_rate) override;
     void reset() override;
     const char* name() const override { return "Amp Sim"; }
+    const char* type_id() const override { return "Amp Sim"; }
     std::vector<EffectParam>& params() override { return params_; }
 
 private:

--- a/src/audio/effects/cabinet_sim.h
+++ b/src/audio/effects/cabinet_sim.h
@@ -23,6 +23,7 @@ public:
     void set_sample_rate(int sample_rate) override;
     void reset() override;
     const char* name() const override { return "Cabinet"; }
+    const char* type_id() const override { return "Cabinet"; }
     std::vector<EffectParam>& params() override { return params_; }
 
     // --- IR management (called from GUI thread) ---

--- a/src/audio/effects/chorus.h
+++ b/src/audio/effects/chorus.h
@@ -17,6 +17,7 @@ public:
     void set_transport_state(float bpm) override;
     void reset() override;
     const char* name() const override { return "Chorus"; }
+    const char* type_id() const override { return "Chorus"; }
     std::vector<EffectParam>& params() override { return params_; }
 
 private:

--- a/src/audio/effects/compressor.h
+++ b/src/audio/effects/compressor.h
@@ -16,6 +16,7 @@ public:
     void process(float* buffer, int num_samples) override;
     void reset() override;
     const char* name() const override { return "Compressor"; }
+    const char* type_id() const override { return "Compressor"; }
     std::vector<EffectParam>& params() override { return params_; }
 
 private:

--- a/src/audio/effects/delay.h
+++ b/src/audio/effects/delay.h
@@ -18,6 +18,7 @@ public:
     void set_transport_state(float bpm) override;
     void reset() override;
     const char* name() const override { return "Delay"; }
+    const char* type_id() const override { return "Delay"; }
     std::vector<EffectParam>& params() override { return params_; }
 
 private:

--- a/src/audio/effects/distortion.h
+++ b/src/audio/effects/distortion.h
@@ -20,6 +20,7 @@ public:
     void reset() override;
     // Return the display name for this effect.
     const char* name() const override { return "Distortion"; }
+    const char* type_id() const override { return "Distortion"; }
     // Return editable parameters exposed by this effect.
     std::vector<EffectParam>& params() override { return params_; }
 

--- a/src/audio/effects/equalizer.h
+++ b/src/audio/effects/equalizer.h
@@ -16,6 +16,7 @@ public:
     void set_sample_rate(int sample_rate) override;
     void reset() override;
     const char* name() const override { return "Equalizer"; }
+    const char* type_id() const override { return "Equalizer"; }
     std::vector<EffectParam>& params() override { return params_; }
 
 private:

--- a/src/audio/effects/flanger.h
+++ b/src/audio/effects/flanger.h
@@ -21,6 +21,7 @@ public:
     void set_sample_rate(int sample_rate) override;
     void reset() override;
     const char* name() const override { return "Flanger"; }
+    const char* type_id() const override { return "Flanger"; }
     std::vector<EffectParam>& params() override { return params_; }
 
 private:

--- a/src/audio/effects/looper.h
+++ b/src/audio/effects/looper.h
@@ -34,6 +34,7 @@ public:
     void set_sample_rate(int sample_rate) override;
     void reset() override;
     const char* name() const override { return "Looper"; }
+    const char* type_id() const override { return "Looper"; }
     std::vector<EffectParam>& params() override { return params_; }
 
     // --- UI control (thread-safe) ---

--- a/src/audio/effects/multiband_compressor.h
+++ b/src/audio/effects/multiband_compressor.h
@@ -92,6 +92,7 @@ public:
     void process(float* buffer, int num_samples) override;
     void reset() override;
     const char* name() const override { return "MultiBand Compressor"; }
+    const char* type_id() const override { return "MultiBand Compressor"; }
     std::vector<EffectParam>& params() override { return params_; }
     void set_sample_rate(int sample_rate) override;
 

--- a/src/audio/effects/noise_gate.h
+++ b/src/audio/effects/noise_gate.h
@@ -16,6 +16,7 @@ public:
     void process(float* buffer, int num_samples) override;
     void reset() override;
     const char* name() const override { return "Noise Gate"; }
+    const char* type_id() const override { return "Noise Gate"; }
     std::vector<EffectParam>& params() override { return params_; }
 
 private:

--- a/src/audio/effects/octaver.h
+++ b/src/audio/effects/octaver.h
@@ -27,6 +27,7 @@ public:
     void set_sample_rate(int sample_rate) override;
     void reset() override;
     const char* name() const override { return "Octaver"; }
+    const char* type_id() const override { return "Octaver"; }
     std::vector<EffectParam>& params() override { return params_; }
 
 private:

--- a/src/audio/effects/overdrive.h
+++ b/src/audio/effects/overdrive.h
@@ -16,6 +16,7 @@ public:
     void process(float* buffer, int num_samples) override;
     void reset() override;
     const char* name() const override { return "Overdrive"; }
+    const char* type_id() const override { return "Overdrive"; }
     std::vector<EffectParam>& params() override { return params_; }
 
 private:

--- a/src/audio/effects/phaser.h
+++ b/src/audio/effects/phaser.h
@@ -22,6 +22,7 @@ public:
     void set_sample_rate(int sample_rate) override;
     void reset() override;
     const char* name() const override { return "Phaser"; }
+    const char* type_id() const override { return "Phaser"; }
     std::vector<EffectParam>& params() override { return params_; }
 
 private:

--- a/src/audio/effects/pitch_shifter.h
+++ b/src/audio/effects/pitch_shifter.h
@@ -27,6 +27,7 @@ public:
     void set_sample_rate(int sample_rate) override;
     void reset() override;
     const char* name() const override { return "Pitch Shifter"; }
+    const char* type_id() const override { return "Pitch Shifter"; }
     std::vector<EffectParam>& params() override { return params_; }
 
 private:

--- a/src/audio/effects/reverb.h
+++ b/src/audio/effects/reverb.h
@@ -17,6 +17,7 @@ public:
     void set_sample_rate(int sample_rate) override;
     void reset() override;
     const char* name() const override { return "Reverb"; }
+    const char* type_id() const override { return "Reverb"; }
     std::vector<EffectParam>& params() override { return params_; }
 
 private:

--- a/src/audio/effects/tuner.h
+++ b/src/audio/effects/tuner.h
@@ -17,6 +17,7 @@ public:
     void set_sample_rate(int sample_rate) override;
     void reset() override;
     const char* name() const override { return "Tuner"; }
+    const char* type_id() const override { return "Tuner"; }
     std::vector<EffectParam>& params() override { return params_; }
 
     // Tuner detection results (audio thread writes, UI thread reads)

--- a/src/audio/effects/wah.h
+++ b/src/audio/effects/wah.h
@@ -16,6 +16,7 @@ public:
     void process(float* buffer, int num_samples) override;
     void reset() override;
     const char* name() const override { return "Wah"; }
+    const char* type_id() const override { return "Wah"; }
     std::vector<EffectParam>& params() override { return params_; }
 
 private:

--- a/src/audio/spsc_queue.h
+++ b/src/audio/spsc_queue.h
@@ -3,6 +3,7 @@
 #include <atomic>
 #include <cstddef>
 #include <type_traits>
+#include <vector>
 
 namespace Amplitron {
 
@@ -53,6 +54,24 @@ public:
         }
         item = buf_[t];
         return true;
+    }
+
+    size_t try_pop_all(std::vector<T>& out_vec) {
+        size_t count = 0;
+        T item;
+        while (try_pop(item)) {
+            out_vec.push_back(item);
+            ++count;
+        }
+        return count;
+    }
+
+    size_t size() const {
+        return (head_.load(std::memory_order_acquire) - tail_.load(std::memory_order_acquire)) & kMask;
+    }
+
+    size_t capacity() const {
+        return Capacity - 1;
     }
 
 private:

--- a/src/preset_manager_io.cpp
+++ b/src/preset_manager_io.cpp
@@ -53,7 +53,7 @@ bool PresetManager::save_preset(const std::string& filepath,
 
     for (auto& fx : engine.effects()) {
         PresetData::EffectData fd;
-        fd.type = fx->name();
+        fd.type = fx->type_id();
         fd.enabled = fx->is_enabled();
         fd.mix = fx->get_mix();
         for (auto& p : fx->params()) {

--- a/tests/test_audio_graph.cpp
+++ b/tests/test_audio_graph.cpp
@@ -27,7 +27,7 @@ std::string mock_save_graph(const AudioGraph &graph) {
 
     if (node.pedal) {
       node_j["effect"] = node.pedal->get_params();
-      node_j["effect"]["type"] = node.pedal->name();
+      node_j["effect"]["type"] = node.pedal->type_id();
     }
 
     node_j["input_pin_ids"] = node.input_pin_ids;

--- a/tests/test_effects.cpp
+++ b/tests/test_effects.cpp
@@ -1590,3 +1590,85 @@ TEST(effect_base_clone_produces_independent_copy) {
     ASSERT_NEAR(copy->get_param_value("Drive"), 3.0f, 1e-5f);
 }
 
+TEST(effect_base_process_stereo_and_helpers) {
+    auto effect = std::make_shared<Overdrive>();
+    effect->set_sample_rate(44100);
+    effect->set_transport_state(120.0f);
+    float left[8] = {1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f};
+    float right[8] = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+    effect->process_stereo(left, right, 8);
+    for (int i = 0; i < 8; ++i) {
+        ASSERT_NEAR(left[i], right[i], 1e-6f);
+    }
+}
+
+TEST(effect_base_apply_mix) {
+    auto sim = std::make_shared<CabinetSim>();
+    sim->set_mix(0.5f);
+    ASSERT_NEAR(sim->get_mix(), 0.5f, 1e-6f);
+    float buffer[8] = {1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f};
+    sim->process(buffer, 8);
+    bool check = false;
+    for (int i = 0; i < 8; ++i) {
+        if (std::abs(buffer[i] - 1.0f) > 1e-6f) {
+            check = true;
+        }
+    }
+    ASSERT_TRUE(check);
+}
+
+TEST(effect_factory_duplicate_registration_throws) {
+    bool threw = false;
+    try {
+        EffectFactory::instance().register_effect("Overdrive", []() {
+            return std::make_shared<Overdrive>();
+        });
+    } catch (const std::runtime_error&) {
+        threw = true;
+    }
+    ASSERT_TRUE(threw);
+}
+
+class MockMixEffect : public Effect {
+public:
+    void process(float* buffer, int num_samples) override {
+        std::vector<float> dry(num_samples);
+        std::memcpy(dry.data(), buffer, static_cast<size_t>(num_samples) * sizeof(float));
+        for (int i = 0; i < num_samples; ++i) {
+            buffer[i] *= 2.0f;
+        }
+        apply_mix(dry.data(), buffer, num_samples);
+    }
+    void reset() override {}
+    const char* name() const override { return "MockMixEffect"; }
+    std::vector<EffectParam>& params() override { return params_; }
+private:
+    std::vector<EffectParam> params_;
+};
+
+TEST(effect_base_get_param_value_fallback) {
+    auto effect = std::make_shared<Overdrive>();
+    ASSERT_NEAR(effect->get_param_value("nonexistent_param"), 0.0f, 1e-6f);
+}
+
+TEST(effect_base_apply_mix_direct) {
+    MockMixEffect effect;
+    effect.set_mix(1.0f);
+    float buffer1[4] = {1.0f, 2.0f, 3.0f, 4.0f};
+    effect.process(buffer1, 4);
+    ASSERT_NEAR(buffer1[0], 2.0f, 1e-6f);
+    ASSERT_NEAR(buffer1[1], 4.0f, 1e-6f);
+    ASSERT_NEAR(buffer1[2], 6.0f, 1e-6f);
+    ASSERT_NEAR(buffer1[3], 8.0f, 1e-6f);
+
+    effect.set_mix(0.5f);
+    float buffer2[4] = {1.0f, 2.0f, 3.0f, 4.0f};
+    effect.process(buffer2, 4);
+    ASSERT_NEAR(buffer2[0], 1.5f, 1e-6f);
+    ASSERT_NEAR(buffer2[1], 3.0f, 1e-6f);
+    ASSERT_NEAR(buffer2[2], 4.5f, 1e-6f);
+    ASSERT_NEAR(buffer2[3], 6.0f, 1e-6f);
+}
+
+
+

--- a/tests/test_effects.cpp
+++ b/tests/test_effects.cpp
@@ -1578,6 +1578,15 @@ TEST(effect_factory_unknown_type_returns_nullptr) {
     ASSERT_EQ(effect2, nullptr);
 }
 
+TEST(effect_type_id_matches_factory_registration) {
+    auto types = EffectFactory::instance().get_all_type_names();
+    for (const auto& type : types) {
+        auto effect = EffectFactory::instance().create(type);
+        ASSERT_NE(effect, nullptr);
+        ASSERT_EQ(std::string(effect->type_id()), type);
+    }
+}
+
 TEST(effect_base_clone_produces_independent_copy) {
     auto original = std::make_shared<Overdrive>();
     original->set_param_by_name("Drive", 2.0f);

--- a/tests/test_effects.cpp
+++ b/tests/test_effects.cpp
@@ -1362,3 +1362,109 @@ TEST(chorus_calculates_correct_rate_from_bpm) {
     // At 120 BPM, the LFO rate should be 2.0 Hz (120 / 60)
     ASSERT_NEAR(ch.params()[0].value, 2.0f, 0.01f);
 }
+
+#include "audio/spsc_queue.h"
+#include "audio/effect_factory.h"
+
+TEST(spsc_queue_try_push_all_drains_queue) {
+    SPSCQueue<float, 8> queue;
+    ASSERT_TRUE(queue.try_push(1.0f));
+    ASSERT_TRUE(queue.try_push(2.0f));
+    ASSERT_TRUE(queue.try_push(3.0f));
+    std::vector<float> out;
+    size_t count = queue.try_pop_all(out);
+    ASSERT_EQ(count, 3u);
+    ASSERT_EQ(out.size(), 3u);
+    ASSERT_NEAR(out[0], 1.0f, 1e-6f);
+    ASSERT_NEAR(out[1], 2.0f, 1e-6f);
+    ASSERT_NEAR(out[2], 3.0f, 1e-6f);
+}
+
+TEST(spsc_queue_full_queue_rejects_push) {
+    SPSCQueue<float, 4> queue;
+    ASSERT_TRUE(queue.try_push(1.0f));
+    ASSERT_TRUE(queue.try_push(2.0f));
+    ASSERT_TRUE(queue.try_push(3.0f));
+    ASSERT_FALSE(queue.try_push(4.0f));
+}
+
+TEST(spsc_queue_try_pop_all_on_empty_returns_empty) {
+    SPSCQueue<float, 8> queue;
+    std::vector<float> out;
+    size_t count = queue.try_pop_all(out);
+    ASSERT_EQ(count, 0u);
+    ASSERT_TRUE(out.empty());
+}
+
+TEST(spsc_queue_size_and_capacity) {
+    SPSCQueue<float, 8> queue;
+    ASSERT_EQ(queue.capacity(), 7u);
+    ASSERT_EQ(queue.size(), 0u);
+    queue.try_push(1.0f);
+    ASSERT_EQ(queue.size(), 1u);
+    queue.try_push(2.0f);
+    ASSERT_EQ(queue.size(), 2u);
+    float val;
+    queue.try_pop(val);
+    ASSERT_EQ(queue.size(), 1u);
+}
+
+TEST(spsc_queue_try_peek) {
+    SPSCQueue<float, 8> queue;
+    float item = 0.0f;
+    ASSERT_FALSE(queue.try_peek(item));
+    queue.try_push(10.5f);
+    ASSERT_TRUE(queue.try_peek(item));
+    ASSERT_NEAR(item, 10.5f, 1e-6f);
+    float item2 = 0.0f;
+    ASSERT_TRUE(queue.try_pop(item2));
+    ASSERT_NEAR(item2, 10.5f, 1e-6f);
+}
+
+TEST(effect_base_get_set_param_by_name) {
+    auto effect = std::make_shared<Overdrive>();
+    effect->set_param_by_name("Drive", 2.0f);
+    ASSERT_NEAR(effect->get_param_value("Drive"), 2.0f, 1e-5f);
+}
+
+TEST(effect_base_get_param_names_not_empty) {
+    auto effect = std::make_shared<Equalizer>();
+    auto names = effect->get_param_names();
+    ASSERT_FALSE(names.empty());
+}
+
+TEST(effect_base_get_display_name) {
+    auto effect = std::make_shared<Overdrive>();
+    ASSERT_TRUE(std::strcmp(effect->get_display_name(), "Overdrive") == 0);
+}
+
+TEST(effect_factory_creates_all_registered_effects) {
+    auto types = EffectFactory::instance().get_all_type_names();
+    ASSERT_FALSE(types.empty());
+    for (const auto& type : types) {
+        auto effect = EffectFactory::instance().create(type);
+        ASSERT_NE(effect, nullptr);
+        auto effect2 = EffectFactory::instance().create_from_type(type);
+        ASSERT_NE(effect2, nullptr);
+    }
+}
+
+TEST(effect_factory_unknown_type_returns_nullptr) {
+    auto effect = EffectFactory::instance().create("nonexistent_effect_type_xyz");
+    ASSERT_EQ(effect, nullptr);
+    auto effect2 = EffectFactory::instance().create_from_type("nonexistent_effect_type_xyz");
+    ASSERT_EQ(effect2, nullptr);
+}
+
+TEST(effect_base_clone_produces_independent_copy) {
+    auto original = std::make_shared<Overdrive>();
+    original->set_param_by_name("Drive", 2.0f);
+    auto copy = original->clone();
+    ASSERT_NE(copy, nullptr);
+    ASSERT_TRUE(std::strcmp(copy->name(), original->name()) == 0);
+    ASSERT_NEAR(copy->get_param_value("Drive"), 2.0f, 1e-5f);
+    copy->set_param_by_name("Drive", 3.0f);
+    ASSERT_NEAR(original->get_param_value("Drive"), 2.0f, 1e-5f);
+    ASSERT_NEAR(copy->get_param_value("Drive"), 3.0f, 1e-5f);
+}
+


### PR DESCRIPTION
Closes #189 
## What does this PR do?
Implements missing API methods in `SPSCQueue`, the base `Effect` class, and the registry-based `EffectFactory` to satisfy the requirements of issue #189 and ensure comprehensive code coverage. 
Specifically, this PR adds:
- **`SPSCQueue`**: `try_pop_all` (for draining all queue contents), `size` (thread-safe, lock-free size check handling wrap-arounds), and `capacity`.
- **`Effect`**: `get_param_names`, `get_param_value`, `set_param_by_name`, `get_display_name`, and `clone`.
- **`EffectFactory`**: `create_from_type` and `get_all_type_names` to resolve and create registered effects, plus the inline logic for `Effect::clone`.
- **Tests**: Comprehensive unit tests covering queue drainage, boundary limits, clone independence, and parameter lookup/clamps.
## Related Issue
Fixes #189
## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor / code cleanup
- [ ] 📝 Documentation
- [x] ✅ Tests
- [ ] 🔧 Build / CI / Configuration
## How Was This Tested?
- Platform(s) tested on: macOS
- Test command run:
- Test Output:
<img width="632" height="411" alt="Screenshot 2026-05-22 at 6 49 15 PM" src="https://github.com/user-attachments/assets/e1801d44-4166-47f7-ad5b-e7ea03aac3d7" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for cloning audio effects with parameter preservation.
  * Added ability to access and modify effect parameters by name.
  * Added factory methods to retrieve all available effect types.
  * Enhanced queue operations with batch item retrieval and occupancy tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sudip-mondal-2002/Amplitron/pull/194?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->