### PR TITLE
Fix #165: Add responsive hamburger menu for mobile navbar

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -477,19 +477,46 @@
             .nav-links a:hover {
                 color: var(--gold);
             }
-            /* Mobile responsive */
-            @media (max-width: 768px) {
-                nav {
-                    padding: 0 24px;
-                    height: 70px;
-                }
-                .nav-logo {
-                    font-size: 20px;
-                }
-                .nav-links {
-                    display: none;
-                }
+            .hamburger {
+                display: none;
+                background: none;
+                border: none;
+                color: var(--gold);
+                font-size: 2rem;
+                cursor: pointer;
             }
+            /* Mobile responsive */
+           @media (max-width: 768px) {
+
+            .hamburger {
+                display: block;
+            }
+
+            .nav-links {
+                position: absolute;
+                top: 70px;
+                right: 0;
+                width: 100%;
+                background: rgba(28, 26, 24, 0.98);
+
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+                gap: 24px;
+
+                padding: 30px 0;
+
+                transform: translateY(-200%);
+                opacity: 0;
+
+                transition: all 0.35s ease;
+            }
+
+            .nav-links.active {
+                transform: translateY(0);
+                opacity: 1;
+            }
+        }
          .product-hunt-wrapper {
     margin-top: 18px;
     display: flex;
@@ -608,7 +635,8 @@
         <!-- Sticky navbar -->
         <nav id="navbar">
             <div class="nav-logo">AMPLITRON</div>
-            <div class="nav-links">
+            <button class="hamburger" id="hamburger">☰</button>
+            <div class="nav-links" id="navLinks">
                 <a href="#features">Features</a>
                 <a href="#downloads">Downloads</a>
                 <a href="#requirements">Requirements</a>
@@ -1149,5 +1177,25 @@
                 }
             }
         </style>
+        <script>
+        document.addEventListener("DOMContentLoaded", () => {
+
+            const hamburger = document.getElementById("hamburger");
+            const navLinks = document.getElementById("navLinks");
+
+            hamburger.addEventListener("click", () => {
+
+                navLinks.classList.toggle("active");
+
+                if (navLinks.classList.contains("active")) {
+                    hamburger.innerHTML = "✕";
+                } else {
+                    hamburger.innerHTML = "☰";
+                }
+
+            });
+
+        });
+        </script>
     </body>
 </html>


### PR DESCRIPTION
## What does this PR do?

Implements a responsive mobile navigation bar with a hamburger menu for smaller screen devices.
The navbar now collapses into a toggleable menu on screens below 768px width, improving accessibility and usability on mobile devices.

## Related Issue

Fixes #165

## Type of Change

- [X] 🐛 Bug fix
- [X] ✨ New feature
- [ ] ♻️ Refactor / code cleanup
- [ ] 📝 Documentation
- [ ] ✅ Tests
- [ ] 🔧 Build / CI / Configuration

## How Was This Tested?

- Platform(s) tested on: 

 - Windows 11

-   Chrome DevTools Mobile View

- Test command run: `./amplitron-tests`

- Manual test steps (if applicable):

1. Opened the Amplitron web app
2. Switched to mobile responsive view
3. Verified hamburger menu appears below 768px width
4. Confirmed clicking hamburger toggles navigation links
5. Verified navbar works correctly on desktop view as well

## Checklist

- [X] Code compiles and builds successfully on my platform
- [X] All existing tests pass (`./amplitron-tests`)
- [ ] New tests added for new functionality (if applicable)
- [X] Documentation updated (README, code comments) if applicable
- [X] No blocking calls on the audio thread (no `std::mutex::lock()` on the hot path)
- [X] Tested on: Windows 11,Chrome Browser

## Screenshots / Demo

<img width="153" height="339" alt="amplitron 1" src="https://github.com/user-attachments/assets/b35fa224-d77d-400b-a571-6162543d5ed3" />


<img width="155" height="341" alt="amplitron 2" src="https://github.com/user-attachments/assets/4710a34e-ff07-4660-804f-8dff41e5be9a" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added hamburger menu for mobile navigation on devices under 768px wide
  * Mobile navigation menu now slides in from the side with smooth animations
  * Menu toggle button displays hamburger (☰) and close (✕) icons

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sudip-mondal-2002/Amplitron/pull/201?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->