### PR TITLE
Fix: Change h1 to h2 in features section for proper accessibility and SEO

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -705,7 +705,8 @@
 
         <section class="features-section" id="features">
             <div class="section-header">
-                <h1>Transform Your Guitar Sound</h1>
+                <!-- Fix: Changed h1 to h2 - page should only have one h1 tag for proper accessibility and SEO -->
+                <h2>Transform Your Guitar Sound</h2>
             </div>
 
             <div class="features-grid">


### PR DESCRIPTION
## What does this PR do?
The features section heading was using an h1 tag instead of h2.
A page should only have one h1 tag for proper accessibility and 
SEO. The h1 is already used for the main logo "AMPLITRON" at 
the top of the page. Changed the features section heading 
"Transform Your Guitar Sound" from h1 to h2.

## Related Issue
Fixes #

## Type of Change
- [x] 🐛 Bug fix

## How Was This Tested?
- Platform(s) tested on: Windows
- Manual test steps:
  1. Open docs/index.html in browser
  2. Inspect the features section heading
  3. Verify it is now an h2 tag
  4. Verify page still renders correctly

## Checklist
- [x] Code compiles and builds successfully on my platform
- [x] Documentation updated (README, code comments) if applicable
- [x] Tested on: Windows

## Screenshots / Demo
No visual change — h1 and h2 render identically with the 
current CSS styling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated heading hierarchy in the features section to improve document structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sudip-mondal-2002/Amplitron/pull/205?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->