### PR TITLE
Test: Improving Reverb and Looper test coverage

### DIFF
--- a/src/audio/effects/looper.cpp
+++ b/src/audio/effects/looper.cpp
@@ -1,6 +1,7 @@
 #include "audio/effects/looper.h"
 #include "audio/effect_factory.h"
 
+#include <ostream>
 #include <algorithm>
 #include <cmath>
 
@@ -249,5 +250,30 @@ void Looper::process_core(float* left, float* right, int num_samples, bool stere
 
     publish_ui_snapshot();
 }
+
+std::ostream& operator<<(std::ostream& os, Looper::State s)
+{
+    switch (s)
+    {
+        case Looper::State::Empty:
+            return os << "Empty";
+
+        case Looper::State::Idle:
+            return os << "Idle";
+
+        case Looper::State::Recording:
+            return os << "Recording";
+
+        case Looper::State::Playing:
+            return os << "Playing";
+
+        case Looper::State::Overdubbing:
+            return os << "Overdubbing";
+
+        default:
+            return os << "Unknown";
+    }
+}
+
 
 } // namespace Amplitron

--- a/src/audio/effects/looper.h
+++ b/src/audio/effects/looper.h
@@ -2,6 +2,7 @@
 
 #include "audio/effect.h"
 
+#include<ostream>
 #include <atomic>
 #include <cmath>
 #include <cstdint>
@@ -108,5 +109,6 @@ private:
     inline void process_core(float* left, float* right, int num_samples, bool stereo);
 };
 
+std::ostream& operator<<(std::ostream& os, Looper::State s);
 } // namespace Amplitron
 

--- a/tests/test_effects.cpp
+++ b/tests/test_effects.cpp
@@ -8,6 +8,7 @@
 #include "audio/effects/chorus.h"
 #include "audio/effects/delay.h"
 #include "audio/effects/reverb.h"
+#include "audio/effects/looper.h"
 #include "audio/effects/cabinet_sim.h"
 #include "audio/effects/amp_simulator.h"
 #include "audio/effects/tuner.h"
@@ -1679,5 +1680,388 @@ TEST(effect_base_apply_mix_direct) {
     ASSERT_NEAR(buffer2[3], 6.0f, 1e-6f);
 }
 
+TEST(reverb_bypass_passes_signal_unchanged) {
+    Reverb rv;
+    rv.set_sample_rate(48000);
+    rv.reset();
+    rv.set_enabled(false);
 
+    float buf[512], orig[512];
+    fill_sine(buf, 512, 440.0f, 48000);
+    std::memcpy(orig, buf, sizeof(buf));
 
+    rv.process(buf, 512);
+
+    for (int i = 0; i < 512; ++i)
+        ASSERT_NEAR(buf[i], orig[i], 1e-6f);
+}
+
+TEST(reverb_reset_clears_tail) {
+    Reverb rv;
+    rv.set_sample_rate(48000);
+
+    float buf[2048];
+    fill_sine(buf, 2048, 440.0f, 48000);
+    rv.process(buf, 2048);   
+
+    rv.reset();
+
+    float silence[2048];
+    std::memset(silence, 0, sizeof(silence));
+    rv.process(silence, 2048);
+
+    ASSERT_NEAR(rms(silence, 2048), 0.0f, 1e-5f);
+}
+
+TEST(reverb_low_decay_shorter_tail_than_high_decay) {
+    auto measure_tail_rms = [](float decay_val) {
+        Reverb rv;
+        rv.set_sample_rate(48000);
+        rv.reset();
+        rv.params()[0].value = decay_val;
+
+        float buf[2048];
+        fill_sine(buf, 2048, 440.0f, 48000);
+        rv.process(buf, 2048);  
+        float silence[2048];
+        std::memset(silence, 0, sizeof(silence));
+        rv.process(silence, 2048);
+        return rms(silence, 2048);
+    };
+
+    float tail_low  = measure_tail_rms(0.1f);
+    float tail_high = measure_tail_rms(0.99f);
+    ASSERT_LT(tail_low, tail_high);
+}
+
+TEST(reverb_high_decay_produces_audible_tail) {
+    Reverb rv;
+    rv.set_sample_rate(48000);
+    rv.reset();
+    rv.params()[0].value = 0.99f;
+
+    float buf[2048];
+    fill_sine(buf, 2048, 440.0f, 48000);
+    rv.process(buf, 2048); 
+
+    float silence[2048];
+    std::memset(silence, 0, sizeof(silence));
+    rv.process(silence, 2048);
+
+    ASSERT_GT(rms(silence, 2048), 0.001f);
+    ASSERT_TRUE(buffer_is_finite(silence, 2048));
+}
+
+TEST(reverb_zero_decay_does_not_generate_signal) {
+    Reverb rv;
+    rv.set_sample_rate(48000);
+    rv.reset();
+    rv.params()[0].value = 0.0f;
+    float buf[2048];
+    std::memset(buf, 0, sizeof(buf));
+    rv.process(buf, 2048);
+
+    ASSERT_NEAR(rms(buf, 2048), 0.0f, 1e-6f);
+    ASSERT_TRUE(buffer_is_finite(buf, 2048));
+}
+
+TEST(reverb_high_damp_reduces_high_freq_content) {
+    auto measure_hf_tail = [](float damp_val) {
+        Reverb rv;
+        rv.set_sample_rate(48000);
+        rv.reset();
+        rv.params()[0].value = 0.8f;      // decay
+        rv.params()[1].value = damp_val;  // damp
+        rv.params()[2].value = 1.0f;      // wet only, if Level is wet mix
+
+        constexpr int N = 2048;
+        constexpr int PRIME = 8192;
+        float prime[PRIME];
+        fill_sine(prime, PRIME, 4000.0f, 48000);
+        rv.process(prime, PRIME);
+
+        float silence[N];
+        float mag = 0.0f;
+
+        for (int b = 0; b < 6; ++b) {
+            std::memset(silence, 0, sizeof(silence));
+            rv.process(silence, N);
+
+            if (b >= 2) { // skip early tail
+                mag += dft_magnitude_at(silence, N, 4000.0f, 48000);
+            }
+        }
+
+        return mag / 4.0f;
+    };
+
+    float hf_undamped = measure_hf_tail(0.0f);
+    float hf_damped   = measure_hf_tail(1.0f);
+    ASSERT_GT(hf_undamped, hf_damped);
+}
+
+TEST(reverb_stereo_produces_finite_decorrelated_output) {
+    Reverb rv;
+    rv.set_sample_rate(48000);
+    rv.reset();
+
+    // Process enough samples for comb filters to fill and diverge between channels.
+    float left[2048], right[2048];
+    fill_sine(left,  2048, 440.0f, 48000);
+    fill_sine(right, 2048, 440.0f, 48000);
+    rv.process_stereo(left, right, 2048);
+
+    ASSERT_TRUE(buffer_is_finite(left,  2048));
+    ASSERT_TRUE(buffer_is_finite(right, 2048));
+    ASSERT_GT(rms(left,  2048), 0.001f);
+    ASSERT_GT(rms(right, 2048), 0.001f);
+
+    float diff = 0.0f;
+    for (int i = 0; i < 2048; ++i) diff += std::fabs(left[i] - right[i]);
+    ASSERT_GT(diff, 1e-3f);
+}
+
+// Looper tests
+
+TEST(looper_initial_state_is_empty) {
+    Looper lp;
+    lp.set_sample_rate(48000);
+    lp.reset();
+    ASSERT_EQ(lp.state(), Looper::State::Empty);
+    ASSERT_FALSE(lp.has_loop());
+    ASSERT_EQ(lp.loop_length_samples(), 0);
+}
+
+TEST(looper_record_then_play) {
+    Looper lp;
+    lp.set_sample_rate(48000);
+    lp.reset();
+
+    // Start recording (command consumed on first process call).
+    lp.request_record_toggle();
+    std::vector<float> rec(9600, 0.0f);  // 0.2 s > kMinLoopSeconds (0.1 s)
+    fill_sine(rec.data(), 9600, 440.0f, 48000);
+    lp.process(rec.data(), 9600);
+    ASSERT_EQ(lp.state(), Looper::State::Recording);
+
+    // Stop recording — looper should auto-switch to Playing.
+    lp.request_record_toggle();
+    float dummy[256] = {};
+    lp.process(dummy, 256);
+    ASSERT_EQ(lp.state(), Looper::State::Playing);
+    ASSERT_TRUE(lp.has_loop());
+    ASSERT_GT(lp.loop_length_samples(), 0);
+}
+
+TEST(looper_short_recording_is_discarded) {
+    // kMinLoopSeconds = 0.10 s → 4800 samples at 48 kHz. 100 samples is far below.
+    Looper lp;
+    lp.set_sample_rate(48000);
+    lp.reset();
+
+    lp.request_record_toggle();
+    float tiny[100] = {};
+    lp.process(tiny, 100);
+
+    lp.request_record_toggle();
+    float dummy[256] = {};
+    lp.process(dummy, 256);
+
+    ASSERT_EQ(lp.state(), Looper::State::Empty);
+    ASSERT_FALSE(lp.has_loop());
+}
+
+TEST(looper_bypass_passes_signal_unchanged) {
+    Looper lp;
+    lp.set_sample_rate(48000);
+    lp.reset();
+    lp.set_enabled(false);
+
+    float buf[512], orig[512];
+    fill_sine(buf, 512, 440.0f, 48000);
+    std::memcpy(orig, buf, sizeof(buf));
+
+    lp.process(buf, 512);
+
+    for (int i = 0; i < 512; ++i)
+        ASSERT_NEAR(buf[i], orig[i], 1e-6f);
+}
+
+TEST(looper_play_toggle_pauses_and_resumes) {
+    Looper lp;
+    lp.set_sample_rate(48000);
+    lp.reset();
+
+    // Build a loop.
+    lp.request_record_toggle();
+    std::vector<float> rec(9600, 0.0f);
+    lp.process(rec.data(), 9600);
+    lp.request_record_toggle();
+    float dummy[256] = {};
+    lp.process(dummy, 256);
+    ASSERT_EQ(lp.state(), Looper::State::Playing);
+
+    // Pause.
+    lp.request_play_toggle();
+    lp.process(dummy, 256);
+    ASSERT_EQ(lp.state(), Looper::State::Idle);
+
+    // Resume.
+    lp.request_play_toggle();
+    lp.process(dummy, 256);
+    ASSERT_EQ(lp.state(), Looper::State::Playing);
+}
+
+TEST(looper_overdub_transition_preserves_loop) {
+    Looper lp;
+    lp.set_sample_rate(48000);
+    lp.reset();
+
+    // Record a silent loop.
+    lp.request_record_toggle();
+    float silence[9600] = {};
+    lp.process(silence, 9600);
+    lp.request_record_toggle();
+    float dummy[256] = {};
+    lp.process(dummy, 256);
+    ASSERT_EQ(lp.state(), Looper::State::Playing);
+
+    // Enter overdub.
+    lp.request_overdub_toggle();
+    float overdub_buf[256];
+    fill_sine(overdub_buf, 256, 440.0f, 48000);
+    lp.process(overdub_buf, 256);
+    ASSERT_EQ(lp.state(), Looper::State::Overdubbing);
+
+    // Exit overdub.
+    lp.request_overdub_toggle();
+    std::memset(dummy, 0, sizeof(dummy));
+    lp.process(dummy, 256);
+    ASSERT_EQ(lp.state(), Looper::State::Playing);
+    ASSERT_TRUE(lp.has_loop());
+}
+
+TEST(looper_overdub_output_is_finite) {
+    Looper lp;
+    lp.set_sample_rate(48000);
+    lp.reset();
+
+    lp.request_record_toggle();
+    float rec[9600];
+    fill_sine(rec, 9600, 440.0f, 48000);
+    lp.process(rec, 9600);
+
+    lp.request_record_toggle();
+    float dummy[256] = {};
+    lp.process(dummy, 256);
+
+    lp.request_overdub_toggle();
+    for (int block = 0; block < 10; ++block) {
+        float buf[256];
+        fill_sine(buf, 256, 880.0f, 48000);
+        lp.process(buf, 256);
+        ASSERT_TRUE(buffer_is_finite(buf, 256));
+    }
+}
+
+TEST(looper_clear_resets_to_empty) {
+    Looper lp;
+    lp.set_sample_rate(48000);
+    lp.reset();
+
+    lp.request_record_toggle();
+    float rec[9600] = {};
+    lp.process(rec, 9600);
+    lp.request_record_toggle();
+    float dummy[256] = {};
+    lp.process(dummy, 256);
+    ASSERT_TRUE(lp.has_loop());
+
+    lp.request_clear();
+    lp.process(dummy, 256);
+
+    ASSERT_EQ(lp.state(), Looper::State::Empty);
+    ASSERT_FALSE(lp.has_loop());
+    ASSERT_EQ(lp.loop_length_samples(), 0);
+}
+
+TEST(looper_stereo_playback_is_finite) {
+    Looper lp;
+    lp.set_sample_rate(48000);
+    lp.reset();
+
+    // Record stereo.
+    lp.request_record_toggle();
+    float left[9600], right[9600];
+    fill_sine(left,  9600, 440.0f, 48000);
+    fill_sine(right, 9600, 880.0f, 48000);
+    lp.process_stereo(left, right, 9600);
+
+    lp.request_record_toggle();
+    float dl[256] = {}, dr[256] = {};
+    lp.process_stereo(dl, dr, 256);
+    ASSERT_EQ(lp.state(), Looper::State::Playing);
+
+    for (int block = 0; block < 5; ++block) {
+        fill_sine(dl, 256, 440.0f, 48000);
+        fill_sine(dr, 256, 880.0f, 48000);
+        lp.process_stereo(dl, dr, 256);
+        ASSERT_TRUE(buffer_is_finite(dl, 256));
+        ASSERT_TRUE(buffer_is_finite(dr, 256));
+    }
+}
+TEST(looper_play_toggle_while_recording_stops_and_enters_playing) {
+    Looper lp;
+    lp.set_sample_rate(48000);
+    lp.reset();
+
+    lp.request_record_toggle();
+    float rec[9600] = {};
+    lp.process(rec, 9600);
+    ASSERT_EQ(lp.state(), Looper::State::Recording);
+
+    lp.request_play_toggle();
+    float dummy[256] = {};
+    lp.process(dummy, 256);
+
+    ASSERT_EQ(lp.state(), Looper::State::Playing);
+    ASSERT_TRUE(lp.has_loop());
+}
+
+// implementation-dependent behaviour, change later if design changes
+TEST(looper_overdub_toggle_from_idle_enters_overdubbing) {
+    Looper lp;
+    lp.set_sample_rate(48000);
+    lp.reset();
+
+    lp.request_record_toggle();
+    float rec[9600] = {};
+    lp.process(rec, 9600);
+    lp.request_record_toggle();
+    float dummy[256] = {};
+    lp.process(dummy, 256);
+
+    lp.request_play_toggle();
+    lp.process(dummy, 256);
+    ASSERT_EQ(lp.state(), Looper::State::Idle);
+
+    lp.request_overdub_toggle();
+    lp.process(dummy, 256);
+    ASSERT_EQ(lp.state(), Looper::State::Overdubbing);
+}
+
+TEST(looper_overdub_toggle_during_recording_is_ignored) {
+    Looper lp;
+    lp.set_sample_rate(48000);
+    lp.reset();
+
+    lp.request_record_toggle();
+    float rec[512] = {};
+    lp.process(rec, 512);
+    ASSERT_EQ(lp.state(), Looper::State::Recording);
+
+    lp.request_overdub_toggle();
+    lp.process(rec, 512);
+
+    ASSERT_EQ(lp.state(), Looper::State::Recording);
+}

--- a/tests/test_effects.cpp
+++ b/tests/test_effects.cpp
@@ -17,6 +17,7 @@
 #include "audio/effects/flanger.h"
 #include "audio/effects/octaver.h"
 #include "audio/effects/pitch_shifter.h"
+#include <sstream>
 #include <cstring>
 #include <cmath>
 
@@ -2064,4 +2065,142 @@ TEST(looper_overdub_toggle_during_recording_is_ignored) {
     lp.process(rec, 512);
 
     ASSERT_EQ(lp.state(), Looper::State::Recording);
+}
+
+TEST(looper_crossfade_wraparound_executes_crossfade_branch) {
+    Looper lp;
+    lp.set_sample_rate(48000);
+    lp.reset();
+
+    // 5 ms -> ~240 samples crossfade.
+    lp.params()[1].value = 5.0f;
+
+    // IMPORTANT:
+    // Use a loop length NOT divisible by block size so playback
+    // eventually lands inside the crossfade region.
+    constexpr int LOOP = 5000;
+    constexpr int N = 256;
+
+    lp.request_record_toggle();
+
+    float rec[LOOP];
+    fill_sine(rec, LOOP, 440.0f, 48000);
+    lp.process(rec, LOOP);
+
+    lp.request_record_toggle();
+
+    float dummy[N] = {};
+    lp.process(dummy, N);
+
+    ASSERT_EQ(lp.state(), Looper::State::Playing);
+
+    // Process enough blocks to guarantee entry into:
+    // pos >= loop_length_ - xf
+    for (int i = 0; i < 40; ++i) {
+        float buf[N];
+        fill_sine(buf, N, 440.0f, 48000);
+
+        lp.process(buf, N);
+
+        ASSERT_TRUE(buffer_is_finite(buf, N));
+    }
+}
+
+TEST(looper_stereo_overdub_executes_right_channel_write_path) {
+    Looper lp;
+    lp.set_sample_rate(48000);
+    lp.reset();
+
+    lp.params()[0].value = 1.0f;
+
+    constexpr int LOOP = 5000;
+    constexpr int N = 256;
+
+    // Record silent stereo loop.
+    lp.request_record_toggle();
+
+    float left[LOOP] = {};
+    float right[LOOP] = {};
+
+    lp.process_stereo(left, right, LOOP);
+
+    lp.request_record_toggle();
+
+    float dl[N] = {}, dr[N] = {};
+    lp.process_stereo(dl, dr, N);
+
+    ASSERT_EQ(lp.state(), Looper::State::Playing);
+    ASSERT_TRUE(lp.has_loop());
+
+    // Enter overdub.
+    lp.request_overdub_toggle();
+
+    // Two blocks guarantees we execute the actual overdub write path
+    // after the state transition.
+    for (int i = 0; i < 2; ++i) {
+        float ol[N], or_[N];
+
+        fill_sine(ol,  N, 440.0f, 48000);
+        fill_sine(or_, N, 880.0f, 48000);
+
+        lp.process_stereo(ol, or_, N);
+
+        ASSERT_TRUE(buffer_is_finite(ol, N));
+        ASSERT_TRUE(buffer_is_finite(or_, N));
+    }
+
+    ASSERT_EQ(lp.state(), Looper::State::Overdubbing);
+}
+
+TEST(looper_state_stream_operator_outputs_expected_strings) {
+    std::ostringstream os;
+
+    os << Looper::State::Empty << " "
+       << Looper::State::Idle << " "
+       << Looper::State::Recording << " "
+       << Looper::State::Playing << " "
+       << Looper::State::Overdubbing;
+
+    ASSERT_EQ(
+        os.str(),
+        "Empty Idle Recording Playing Overdubbing"
+    );
+}
+
+TEST(looper_state_stream_operator_handles_unknown_value) {
+    std::ostringstream os;
+
+    auto invalid =
+        static_cast<Looper::State>(999);
+
+    os << invalid;
+
+    ASSERT_EQ(os.str(), "Unknown");
+}
+
+TEST(looper_metadata_accessors_return_expected_values) {
+    Looper lp;
+
+    ASSERT_EQ(std::string(lp.name()), "Looper");
+    ASSERT_EQ(std::string(lp.type_id()), "Looper");
+
+    auto& p = lp.params();
+
+    ASSERT_FALSE(p.empty());
+    ASSERT_GE(p.size(), 2u);
+}
+
+TEST(looper_recording_auto_stops_at_buffer_limit) {
+    // sr=100 gives max_samples_=6000; feeding 7000 samples triggers the cap.
+    Looper lp;
+    lp.set_sample_rate(100);
+    lp.reset();
+
+    lp.request_record_toggle();
+    std::vector<float> rec(7000, 0.5f);
+    lp.process(rec.data(), 7000);
+
+    ASSERT_EQ(lp.state(), Looper::State::Playing);
+    ASSERT_TRUE(lp.has_loop());
+    ASSERT_EQ(lp.loop_length_samples(), 6000);
 }

--- a/tests/test_effects.cpp
+++ b/tests/test_effects.cpp
@@ -2080,6 +2080,7 @@ TEST(looper_crossfade_wraparound_executes_crossfade_branch) {
     // eventually lands inside the crossfade region.
     constexpr int LOOP = 5000;
     constexpr int N = 256;
+    constexpr int XF = 240; // 5 ms at 48 kHz
 
     lp.request_record_toggle();
 
@@ -2096,7 +2097,11 @@ TEST(looper_crossfade_wraparound_executes_crossfade_branch) {
 
     // Process enough blocks to guarantee entry into:
     // pos >= loop_length_ - xf
+    bool entered_crossfade_region = false;
     for (int i = 0; i < 40; ++i) {
+        if (lp.playhead_samples() >= (LOOP - XF)) {
+            entered_crossfade_region = true;
+        }
         float buf[N];
         fill_sine(buf, N, 440.0f, 48000);
 
@@ -2104,52 +2109,49 @@ TEST(looper_crossfade_wraparound_executes_crossfade_branch) {
 
         ASSERT_TRUE(buffer_is_finite(buf, N));
     }
+    ASSERT_TRUE(entered_crossfade_region);
 }
 
 TEST(looper_stereo_overdub_executes_right_channel_write_path) {
     Looper lp;
     lp.set_sample_rate(48000);
     lp.reset();
-
     lp.params()[0].value = 1.0f;
 
     constexpr int LOOP = 5000;
     constexpr int N = 256;
 
-    // Record silent stereo loop.
     lp.request_record_toggle();
-
     float left[LOOP] = {};
     float right[LOOP] = {};
-
     lp.process_stereo(left, right, LOOP);
 
     lp.request_record_toggle();
-
     float dl[N] = {}, dr[N] = {};
     lp.process_stereo(dl, dr, N);
-
     ASSERT_EQ(lp.state(), Looper::State::Playing);
-    ASSERT_TRUE(lp.has_loop());
 
-    // Enter overdub.
     lp.request_overdub_toggle();
 
-    // Two blocks guarantees we execute the actual overdub write path
-    // after the state transition.
-    for (int i = 0; i < 2; ++i) {
-        float ol[N], or_[N];
-
-        fill_sine(ol,  N, 440.0f, 48000);
+    // ceil(5000/256) = 20 blocks covers the full loop.
+    // Left channel stays silent; right channel gets a sine.
+    // After 20 blocks every position in buffer_r_ has been written.
+    for (int i = 0; i < 20; ++i) {
+        float ol[N] = {};
+        float or_[N];
         fill_sine(or_, N, 880.0f, 48000);
-
         lp.process_stereo(ol, or_, N);
-
-        ASSERT_TRUE(buffer_is_finite(ol, N));
         ASSERT_TRUE(buffer_is_finite(or_, N));
     }
-
     ASSERT_EQ(lp.state(), Looper::State::Overdubbing);
+
+    // Exit overdub and play back silence — right channel should have
+    // loop content, left should not.
+    lp.request_overdub_toggle();
+    float pl[N] = {}, pr[N] = {};
+    lp.process_stereo(pl, pr, N);
+
+    ASSERT_GT(rms(pr, N), rms(pl, N) * 2.0f);
 }
 
 TEST(looper_state_stream_operator_outputs_expected_strings) {


### PR DESCRIPTION
## What does this PR do?
This PR expands behavioral and regression test coverage for the Reverb and Looper.

Reverb coverage additions:
- Added bypass passthrough tests
- Added reset behavior tests to verify delay-line state is cleared
- Added low vs high decay tail persistence tests
- Added high decay (0.99) long-tail persistence checks
- Added zero-decay stability tests
- Added damping regression tests to verify high-frequency attenuation behavior
- Added stereo decorrelation and finite-output stability tests

Looper coverage additions:
- Added initial state tests
- Added record → playback transition tests
- Added short-recording rejection tests
- Added bypass passthrough tests
- Added play/pause toggle tests
- Added overdub transition and invalid-transition tests
- Added stereo playback stability tests
- Added clear/reset behavior tests
- Added finite-output stability checks during overdubbing

Miscellaneous:
- Added the `<ostream> `required for` Looper::State` stream operator support.
<!-- Brief description of the change -->

Note: The issue description referenced `undo_overdub()` and `set_speed(0.5f)`. However these features do not appear to exist in the current Looper implementation. The added tests therefore focus on what has been currently implemented.

## Related Issue
Improves coverage for:

- `reverb.cpp`
- `looper.cpp`
- `looper.h`

<!-- Link to the issue this PR addresses -->
Fixes #185 

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor / code cleanup
- [ ] 📝 Documentation
- [x] ✅ Tests
- [ ] 🔧 Build / CI / Configuration

## How Was This Tested?

<!-- Describe how you tested the change -->
- Platform(s) tested on: MacOS
- Test command run: `./amplitron-tests`

## Checklist

- [x] Code compiles and builds successfully on my platform
- [x] All existing tests pass (`./amplitron-tests`)
- [ ] New tests added for new functionality (if applicable)
- [ ] Documentation updated (README, code comments) if applicable
- [x] No blocking calls on the audio thread (no `std::mutex::lock()` on the hot path)
- [x] Tested on: MacOS

## Screenshots / Demo

<img width="1282" height="1108" alt="image" src="https://github.com/user-attachments/assets/06330a20-6f17-4cc1-80ba-fa333db4327d" />
<img width="1282" height="158" alt="image" src="https://github.com/user-attachments/assets/86c74067-708c-4993-9df5-ee5461707746" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds human-readable textual output for looper state values (prints known state names, falls back to "Unknown" for others).

* **Tests**
  * Added comprehensive tests for looper and reverb effects covering state transitions, recording/playback/overdub behaviors, bypass handling, output finiteness and stereo checks, metadata expectations, auto-stop at caps, crossfade/branch cases, and stream-format validation for looper states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sudip-mondal-2002/Amplitron/pull/213?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->