### PR TITLE
Add: parallel amp blend graph preset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ presets/*
 !presets/04_Ambient_Swells.json
 !presets/05_Phase_Shift_Lead.json
 !presets/06_Jet_Flanger.json
+!presets/06_Parallel_Amp_Blend.json
 recordings/
 
 # IDE

--- a/docs/PRESETS.md
+++ b/docs/PRESETS.md
@@ -38,6 +38,25 @@ You can load these presets directly from the "Presets" menu in the GUI.
 * **Active Effects:** Noise Gate, Compressor, Equalizer, Phaser, Delay, Reverb, Amp Sim
 * **Use Case:** Classic rock solos, funky chords, and psychedelic textures. Inspired by the legendary MXR Phase 90 in 4-stage mode. Subtle delay adds depth to the sweep.
 
+### `06 Parallel Amp Blend`
+* **Style:** Two-amp studio rig with dirty British crunch blended against clean American sparkle
+* **Amp Models:** British Crunch (Marshall JCM800) and Clean American (Fender Twin)
+* **Active Effects:** Noise Gate, Compressor, Splitter, Overdrive, two Amp Sims, two Cabinets, Mixer, Reverb
+* **Use Case:** Big rhythm parts, layered lead tones, and session-style clean/dirty blending. The Splitter sends the compressed guitar to both amp paths, the Mixer starts at a 50/50 blend, and the Reverb sits after the Mixer so both amps share the same ambience.
+
+```text
+Input
+  -> Noise Gate -> Compressor
+       -> Splitter
+            -> Path A: Overdrive -> Amp Sim (British Crunch) -> Cabinet
+            -> Path B:             Amp Sim (Clean American)  -> Cabinet
+       -> Mixer (A 0.50 / B 0.50)
+       -> Reverb -> Output
+```
+
+* **Blend Tip:** Raise Mixer input A for more overdriven Marshall bite, or raise Mixer input B for a cleaner Fender foundation. Keep both near 0.5 for the default balanced blend.
+* **Gain Tip:** If the preset clips after changing the blend, lower the louder Amp Sim `Level` first, then fine-tune `Output Gain`.
+
 ### `06 Jet Flanger`
 * **Style:** Dramatic jet-plane flanger sweep with strong resonance
 * **Amp Model:** Jazz Warm (Roland JC-120)
@@ -51,3 +70,4 @@ The provided presets sound great, but their response depends heavily on your spe
 * **Noise Gate Threshold:** If you're using single-coil pickups, you may hear a 60-cycle hum on the high-gain patches (`03 Modern Metal Lead`). Try lowering the `Threshold` knob on the Noise Gate until the hum disappears while you aren't playing.
 * **Input Gain/Amp Gain:** If your guitar uses high-output active pickups (like EMGs), the clean presets might distort slightly. You can counter this by slightly lowering the `Input Gain` in the main UI, or lowering the `Gain` knob directly on the `Amp Sim` effect block.
 * **EQ Balancing:** Different woods and pickup styles impart different EQ curves. Use the `Equalizer` effect block to shape the sound. If a tone sounds muddy on your neck pickup, try cutting `Bass` or slightly boosting `Presence`.
+* **Parallel Blend:** On `06 Parallel Amp Blend`, the Mixer's A and B sliders control the dirty and clean paths. Small changes go a long way; try A 0.65 / B 0.35 for a rock-forward tone, or A 0.35 / B 0.65 for clearer chords.

--- a/presets/06_Parallel_Amp_Blend.json
+++ b/presets/06_Parallel_Amp_Blend.json
@@ -1,0 +1,227 @@
+{
+  "format_version": 2,
+  "name": "06 Parallel Amp Blend",
+  "description": "Parallel clean American and dirty British amp paths blended at a 50/50 Mixer, with shared reverb after the merge.",
+  "saved_at": "2026-05-24T12:00:00",
+  "input_gain": 0.75,
+  "output_gain": 0.8,
+  "nodes": [
+    {
+      "id": 1,
+      "name": "Input",
+      "routing_type": 0,
+      "is_graph_input": true,
+      "is_graph_output": false,
+      "x": 40.0,
+      "y": 220.0,
+      "input_pin_ids": [2],
+      "output_pin_ids": [3]
+    },
+    {
+      "id": 4,
+      "name": "Noise Gate",
+      "routing_type": 0,
+      "is_graph_input": false,
+      "is_graph_output": false,
+      "x": 230.0,
+      "y": 220.0,
+      "effect": {
+        "type": "Noise Gate",
+        "enabled": true,
+        "mix": 1.0,
+        "Threshold": -55.0,
+        "Attack": 0.5,
+        "Release": 60.0
+      },
+      "input_pin_ids": [5],
+      "output_pin_ids": [6]
+    },
+    {
+      "id": 7,
+      "name": "Compressor",
+      "routing_type": 0,
+      "is_graph_input": false,
+      "is_graph_output": false,
+      "x": 450.0,
+      "y": 220.0,
+      "effect": {
+        "type": "Compressor",
+        "enabled": true,
+        "mix": 1.0,
+        "Threshold": -22.0,
+        "Ratio": 3.0,
+        "Attack": 8.0,
+        "Release": 140.0,
+        "Makeup": 2.0
+      },
+      "input_pin_ids": [8],
+      "output_pin_ids": [9]
+    },
+    {
+      "id": 10,
+      "name": "Splitter",
+      "routing_type": 1,
+      "is_graph_input": false,
+      "is_graph_output": false,
+      "x": 680.0,
+      "y": 245.0,
+      "input_pin_ids": [11],
+      "output_pin_ids": [12, 13]
+    },
+    {
+      "id": 14,
+      "name": "Overdrive",
+      "routing_type": 0,
+      "is_graph_input": false,
+      "is_graph_output": false,
+      "x": 900.0,
+      "y": 40.0,
+      "effect": {
+        "type": "Overdrive",
+        "enabled": true,
+        "mix": 1.0,
+        "Drive": 4.2,
+        "Tone": 0.68,
+        "Level": 0.78
+      },
+      "input_pin_ids": [15],
+      "output_pin_ids": [16]
+    },
+    {
+      "id": 17,
+      "name": "Amp Sim",
+      "routing_type": 0,
+      "is_graph_input": false,
+      "is_graph_output": false,
+      "x": 1120.0,
+      "y": 40.0,
+      "effect": {
+        "type": "Amp Sim",
+        "enabled": true,
+        "mix": 1.0,
+        "Model": 1.0,
+        "Gain": 0.68,
+        "Bass": -0.5,
+        "Mid": 2.0,
+        "Treble": 1.0,
+        "Level": 0.72
+      },
+      "input_pin_ids": [18],
+      "output_pin_ids": [19]
+    },
+    {
+      "id": 20,
+      "name": "Cabinet",
+      "routing_type": 0,
+      "is_graph_input": false,
+      "is_graph_output": false,
+      "x": 1340.0,
+      "y": 40.0,
+      "effect": {
+        "type": "Cabinet",
+        "enabled": true,
+        "mix": 1.0,
+        "Type": 2.0,
+        "Bright": 0.55
+      },
+      "input_pin_ids": [21],
+      "output_pin_ids": [22]
+    },
+    {
+      "id": 23,
+      "name": "Amp Sim",
+      "routing_type": 0,
+      "is_graph_input": false,
+      "is_graph_output": false,
+      "x": 900.0,
+      "y": 430.0,
+      "effect": {
+        "type": "Amp Sim",
+        "enabled": true,
+        "mix": 1.0,
+        "Model": 0.0,
+        "Gain": 0.35,
+        "Bass": 0.8,
+        "Mid": -1.5,
+        "Treble": 1.6,
+        "Level": 0.78
+      },
+      "input_pin_ids": [24],
+      "output_pin_ids": [25]
+    },
+    {
+      "id": 26,
+      "name": "Cabinet",
+      "routing_type": 0,
+      "is_graph_input": false,
+      "is_graph_output": false,
+      "x": 1120.0,
+      "y": 430.0,
+      "effect": {
+        "type": "Cabinet",
+        "enabled": true,
+        "mix": 1.0,
+        "Type": 1.0,
+        "Bright": 0.6
+      },
+      "input_pin_ids": [27],
+      "output_pin_ids": [28]
+    },
+    {
+      "id": 29,
+      "name": "Mixer",
+      "routing_type": 2,
+      "is_graph_input": false,
+      "is_graph_output": false,
+      "x": 1560.0,
+      "y": 255.0,
+      "input_pin_ids": [30, 31],
+      "output_pin_ids": [32],
+      "input_gains": [0.5, 0.5]
+    },
+    {
+      "id": 33,
+      "name": "Reverb",
+      "routing_type": 0,
+      "is_graph_input": false,
+      "is_graph_output": false,
+      "x": 1780.0,
+      "y": 220.0,
+      "effect": {
+        "type": "Reverb",
+        "enabled": true,
+        "mix": 1.0,
+        "Decay": 0.48,
+        "Damp": 0.42,
+        "Level": 0.28
+      },
+      "input_pin_ids": [34],
+      "output_pin_ids": [35]
+    },
+    {
+      "id": 36,
+      "name": "Output",
+      "routing_type": 0,
+      "is_graph_input": false,
+      "is_graph_output": true,
+      "x": 2000.0,
+      "y": 220.0,
+      "input_pin_ids": [37],
+      "output_pin_ids": [38]
+    }
+  ],
+  "links": [
+    { "id": 39, "source_pin_id": 3, "dest_pin_id": 5 },
+    { "id": 40, "source_pin_id": 6, "dest_pin_id": 8 },
+    { "id": 41, "source_pin_id": 9, "dest_pin_id": 11 },
+    { "id": 42, "source_pin_id": 12, "dest_pin_id": 15 },
+    { "id": 43, "source_pin_id": 16, "dest_pin_id": 18 },
+    { "id": 44, "source_pin_id": 19, "dest_pin_id": 21 },
+    { "id": 45, "source_pin_id": 13, "dest_pin_id": 24 },
+    { "id": 46, "source_pin_id": 25, "dest_pin_id": 27 },
+    { "id": 47, "source_pin_id": 22, "dest_pin_id": 30 },
+    { "id": 48, "source_pin_id": 28, "dest_pin_id": 31 },
+    { "id": 49, "source_pin_id": 32, "dest_pin_id": 34 },
+    { "id": 50, "source_pin_id": 35, "dest_pin_id": 37 }
+  ]
+}

--- a/src/audio/audio_engine.h
+++ b/src/audio/audio_engine.h
@@ -114,6 +114,7 @@ public:
     /** @brief Direct access to the effect chain vector (GUI thread only). */
     AudioGraph& graph() { return main_graph_; }
     const AudioGraph& graph() const { return main_graph_; }
+    void replace_graph(AudioGraph graph, std::vector<std::shared_ptr<Effect>> effects);
 
     // =========================================================================
     // TEMPORARY COMPILER BRIDGE 

--- a/src/audio/audio_engine_chain.cpp
+++ b/src/audio/audio_engine_chain.cpp
@@ -1,5 +1,6 @@
 #include "audio/audio_engine.h"
 #include <algorithm>
+#include <utility>
 
 namespace Amplitron {
 
@@ -97,6 +98,22 @@ void AudioEngine::sync_graph_with_dummy_effects(bool reset_graph) {
 void AudioEngine::add_effect(std::shared_ptr<Effect> fx) {
     dummy_effects_.push_back(fx);
     sync_graph_with_dummy_effects();
+}
+
+void AudioEngine::replace_graph(AudioGraph graph, std::vector<std::shared_ptr<Effect>> effects) {
+    {
+        std::lock_guard<std::mutex> lock(effect_mutex_);
+        for (const auto& fx : effects) {
+            if (fx) {
+                fx->set_sample_rate(sample_rate_);
+                fx->reset();
+            }
+        }
+        dummy_effects_ = std::move(effects);
+        main_graph_ = std::move(graph);
+    }
+
+    commit_graph_changes();
 }
 
 void AudioEngine::insert_effect(int index, std::shared_ptr<Effect> fx) {

--- a/src/audio/audio_graph.cpp
+++ b/src/audio/audio_graph.cpp
@@ -17,6 +17,8 @@ int AudioGraph::add_node(const std::string &name, NodeRoutingType type,
   if (type == NodeRoutingType::Mixer || type == NodeRoutingType::MergeSum) {
     node.input_pin_ids.push_back(next_id_++);  // Input Pin Branch A
     node.input_pin_ids.push_back(next_id_++);  // Input Pin Branch B
+    node.input_gains.push_back(0.5f);
+    node.input_gains.push_back(0.5f);
     node.output_pin_ids.push_back(next_id_++); // 1 Output Pin
   } else if (type == NodeRoutingType::Splitter) {
     node.input_pin_ids.push_back(next_id_++);  // 1 Input Pin
@@ -115,6 +117,16 @@ void AudioGraph::set_node_position(int node_id, float x, float y) {
     if (node.id == node_id) {
       node.x = x;
       node.y = y;
+      break;
+    }
+  }
+}
+
+void AudioGraph::set_node_input_gain(int node_id, size_t input_index,
+                                     float gain) {
+  for (auto &node : nodes_) {
+    if (node.id == node_id && input_index < node.input_gains.size()) {
+      node.input_gains[input_index] = std::clamp(gain, 0.0f, 1.0f);
       break;
     }
   }

--- a/src/audio/audio_graph.h
+++ b/src/audio/audio_graph.h
@@ -24,6 +24,7 @@ struct DSPNode {
 
   std::vector<int> input_pin_ids;
   std::vector<int> output_pin_ids;
+  std::vector<float> input_gains;
 
   bool is_graph_input = false;
   bool is_graph_output = false;
@@ -54,6 +55,7 @@ public:
   void set_node_as_input(int node_id, bool is_input);
   void set_node_as_output(int node_id, bool is_output);
   void set_node_position(int node_id, float x, float y);
+  void set_node_input_gain(int node_id, size_t input_index, float gain);
 
   // Topological Order & Loop Validation Core
   bool rebuild_topology();

--- a/src/audio/audio_graph_executor.cpp
+++ b/src/audio/audio_graph_executor.cpp
@@ -78,12 +78,19 @@ void AudioGraphExecutor::compile(const AudioGraph& graph) {
         }
 
         // Trace upstream connections to find which buffers to read from
-        for (int in_pin : it->input_pin_ids) {
+        for (size_t input_index = 0; input_index < it->input_pin_ids.size();
+             ++input_index) {
+            int in_pin = it->input_pin_ids[input_index];
             for (const auto& link : links) {
                 if (link.dest_pin_id == in_pin) {
                     int src_node_id = graph.get_node_from_pin(link.source_pin_id);
                     if (src_node_id != -1 && node_to_buffer.count(src_node_id)) {
-                        step.input_sources.push_back({ node_to_buffer[src_node_id] });
+                        float gain = 1.0f;
+                        if (it->routing_type == NodeRoutingType::Mixer &&
+                            input_index < it->input_gains.size()) {
+                            gain = it->input_gains[input_index];
+                        }
+                        step.input_sources.push_back({ node_to_buffer[src_node_id], gain });
                     }
                 }
             }
@@ -129,7 +136,7 @@ void AudioGraphExecutor::process(const float* input, float* output, int num_samp
             for (const auto& src : step.input_sources) {
                 const float* src_buf = buffer_pool_[src.buffer_index].data();
                 for (int i = 0; i < num_samples; ++i) {
-                    node_input[i] += src_buf[i];
+                    node_input[i] += src_buf[i] * src.gain;
                 }
             }
         }

--- a/src/audio/audio_graph_executor.h
+++ b/src/audio/audio_graph_executor.h
@@ -34,6 +34,7 @@ private:
 
     struct InputSource {
         int buffer_index; // The pool index to read from
+        float gain = 1.0f;
     };
 
     struct NodeExecutionStep {

--- a/src/gui/pedal_board_chain.cpp
+++ b/src/gui/pedal_board_chain.cpp
@@ -7,6 +7,7 @@
 #include <imgui.h>
 #include <unordered_map>
 #include <cmath>
+#include <cstdio>
 
 namespace Amplitron {
 
@@ -94,6 +95,11 @@ void PedalBoard::render_signal_chain() {
     // Give all new nodes a default position at the end of the chain without shifting existing nodes
     for (const auto& node : audio_graph.get_nodes()) {
         if (ui_state.node_positions.find(node.id) == ui_state.node_positions.end()) {
+            if (node.x != 0.0f || node.y != 0.0f) {
+                ui_state.node_positions[node.id] = { ImVec2(node.x, node.y), false };
+                continue;
+            }
+
             float max_right = 40.0f;
             for (const auto& existing_node : audio_graph.get_nodes()) {
                 auto pos_it = ui_state.node_positions.find(existing_node.id);
@@ -138,8 +144,11 @@ void PedalBoard::render_signal_chain() {
         if (target_widget && std::strcmp(target_widget->get_effect()->name(), "MultiBand Compressor") == 0) {
             is_mb_comp = true;
         }
-        float node_width = (target_widget ? (is_mb_comp ? 190.0f * 2.2f : 190.0f) : 110.0f) * ui_state.zoom;
-        float node_height = (target_widget ? 360.0f : 70.0f) * ui_state.zoom;
+        bool is_mixer_node = node.routing_type == NodeRoutingType::Mixer;
+        float utility_width = is_mixer_node ? 155.0f : 110.0f;
+        float utility_height = is_mixer_node ? 120.0f : 70.0f;
+        float node_width = (target_widget ? (is_mb_comp ? 190.0f * 2.2f : 190.0f) : utility_width) * ui_state.zoom;
+        float node_height = (target_widget ? 360.0f : utility_height) * ui_state.zoom;
 
         ImGui::PushID(node.id);
 
@@ -166,7 +175,8 @@ void PedalBoard::render_signal_chain() {
 
             ImGui::SetCursorScreenPos(node_screen_pos);
             ImGui::SetNextItemAllowOverlap();
-            ImGui::InvisibleButton("util_drag_handle", ImVec2(node_width - 25.0f * ui_state.zoom, node_height));
+            float drag_height = is_mixer_node ? 32.0f * ui_state.zoom : node_height;
+            ImGui::InvisibleButton("util_drag_handle", ImVec2(node_width - 25.0f * ui_state.zoom, drag_height));
             if (!ui_state.hand_tool_active && ImGui::IsItemActive() && ImGui::IsMouseDragging(ImGuiMouseButton_Left)) {
                 node_layout.position.x += ImGui::GetIO().MouseDelta.x / ui_state.zoom;
                 node_layout.position.y += ImGui::GetIO().MouseDelta.y / ui_state.zoom;
@@ -175,6 +185,30 @@ void PedalBoard::render_signal_chain() {
             ImGui::SetWindowFontScale(ui_state.zoom);
             draw_list->AddText(text_pos, IM_COL32(255, 255, 255, 255), node.name.c_str());
             ImGui::SetWindowFontScale(1.0f);
+
+            if (is_mixer_node) {
+                for (size_t gain_index = 0; gain_index < node.input_pin_ids.size() &&
+                                            gain_index < node.input_gains.size();
+                     ++gain_index) {
+                    float gain = node.input_gains[gain_index];
+                    float row_y = node_screen_pos.y + (50.0f + gain_index * 30.0f) * ui_state.zoom;
+                    ImVec2 label_pos(node_screen_pos.x + 12.0f * ui_state.zoom, row_y + 4.0f * ui_state.zoom);
+                    char label[8];
+                    std::snprintf(label, sizeof(label), "%c", static_cast<char>('A' + gain_index));
+                    draw_list->AddText(label_pos, IM_COL32(220, 220, 220, 255), label);
+
+                    ImGui::SetCursorScreenPos(ImVec2(node_screen_pos.x + 32.0f * ui_state.zoom, row_y));
+                    ImGui::SetNextItemWidth(105.0f * ui_state.zoom);
+                    std::string slider_id = "##mixer_gain_" + std::to_string(node.id) + "_" + std::to_string(gain_index);
+                    if (ImGui::SliderFloat(slider_id.c_str(), &gain, 0.0f, 1.0f, "%.2f")) {
+                        audio_graph.set_node_input_gain(node.id, gain_index, gain);
+                        engine_.commit_graph_changes();
+                    }
+                    if (ImGui::IsItemHovered()) {
+                        ImGui::SetTooltip("Mixer input %c gain", static_cast<char>('A' + gain_index));
+                    }
+                }
+            }
         }
 
         if (!node.is_reachable) {
@@ -347,7 +381,7 @@ void PedalBoard::render_signal_chain() {
         // ====================================================================
         // FIX: THE WIRE DRAG START (Output Pins)
         // ====================================================================
-        if (!is_amp) {
+        if (!node.output_pin_ids.empty() && !node.is_graph_output) {
             for (size_t idx = 0; idx < node.output_pin_ids.size(); ++idx) {
                 int pin_id = node.output_pin_ids[idx];
                 float pin_y = node_screen_pos.y + (node_height * (idx + 1.0f) / (node.output_pin_ids.size() + 1.0f));

--- a/src/preset_manager_io.cpp
+++ b/src/preset_manager_io.cpp
@@ -1,12 +1,190 @@
 #include "preset_manager.h"
 #include "preset_json.h"
+#include "common.h"
+#include "audio/audio_graph.h"
 #include "audio/effect_factory.h"
 #include "audio/effects/cabinet_sim.h"
 #include "preset_manager_impl.h"
 #include <iostream>
+#include <fstream>
 #include <cstring>
+#include <map>
+#include <nlohmann/json.hpp>
+#include <utility>
 
 namespace Amplitron {
+
+namespace {
+
+bool is_valid_routing_type(int value) {
+    return value == static_cast<int>(NodeRoutingType::StandardEffect) ||
+           value == static_cast<int>(NodeRoutingType::Splitter) ||
+           value == static_cast<int>(NodeRoutingType::Mixer);
+}
+
+bool load_graph_preset(const nlohmann::json& j,
+                       const std::string& filepath,
+                       AudioEngine& engine,
+                       MidiManager* midi_manager,
+                       std::string& error) {
+    if (!j.contains("nodes") || !j["nodes"].is_array() ||
+        !j.contains("links") || !j["links"].is_array()) {
+        error = "Graph preset is missing nodes or links: " + filepath;
+        std::cerr << error << std::endl;
+        return false;
+    }
+
+    try {
+        AudioGraph graph;
+        std::vector<std::shared_ptr<Effect>> loaded_effects;
+        std::map<int, int> pin_map;
+
+        for (const auto& node_j : j["nodes"]) {
+            if (!node_j.contains("id") || !node_j.contains("routing_type")) {
+                error = "Graph preset node is missing id or routing_type: " + filepath;
+                std::cerr << error << std::endl;
+                return false;
+            }
+
+            std::shared_ptr<Effect> effect = nullptr;
+            if (node_j.contains("effect") && node_j["effect"].is_object()) {
+                nlohmann::json effect_j = node_j["effect"];
+                std::string type = effect_j.value("type", std::string{});
+                if (type == "IR Cabinet") {
+                    type = "Cabinet";
+                }
+
+                if (!type.empty()) {
+                    effect = EffectFactory::instance().create(type);
+                    if (!effect) {
+                        error = "Unknown graph preset effect type: " + type;
+                        std::cerr << error << std::endl;
+                        return false;
+                    }
+
+                    effect->set_params(effect_j);
+
+                    if (effect_j.contains("metadata") && effect_j["metadata"].is_object()) {
+                        std::string ir_path = effect_j["metadata"].value("ir_path", std::string{});
+                        if (!ir_path.empty()) {
+                            auto* cab = dynamic_cast<CabinetSim*>(effect.get());
+                            if (cab && !cab->load_ir(ir_path)) {
+                                std::cerr << "Cabinet: could not load IR file: "
+                                          << ir_path << std::endl;
+                            }
+                        }
+                    }
+
+                    loaded_effects.push_back(effect);
+                }
+            }
+
+            int routing_type_raw = node_j.value("routing_type", -1);
+            if (!is_valid_routing_type(routing_type_raw)) {
+                error = "Graph preset node has invalid routing_type: " + filepath;
+                std::cerr << error << std::endl;
+                return false;
+            }
+            NodeRoutingType routing_type = static_cast<NodeRoutingType>(routing_type_raw);
+            std::string default_name = effect ? std::string(effect->name()) : std::string("Node");
+            std::string node_name = node_j.value("name", default_name);
+            int new_id = graph.add_node(node_name, routing_type, effect);
+
+            graph.set_node_as_input(new_id, node_j.value("is_graph_input", false));
+            graph.set_node_as_output(new_id, node_j.value("is_graph_output", false));
+            graph.set_node_position(new_id,
+                                    node_j.value("x", 0.0f),
+                                    node_j.value("y", 0.0f));
+
+            if (node_j.contains("input_gains") && node_j["input_gains"].is_array()) {
+                for (size_t i = 0; i < node_j["input_gains"].size(); ++i) {
+                    if (node_j["input_gains"][i].is_number()) {
+                        graph.set_node_input_gain(new_id, i,
+                                                  node_j["input_gains"][i].get<float>());
+                    }
+                }
+            }
+
+            const auto* new_node = graph.find_node(new_id);
+            if (!new_node) {
+                error = "Could not create graph preset node: " + node_name;
+                std::cerr << error << std::endl;
+                return false;
+            }
+
+            if (node_j.contains("input_pin_ids") && node_j["input_pin_ids"].is_array()) {
+                const auto& old_pins = node_j["input_pin_ids"];
+                for (size_t i = 0; i < old_pins.size() && i < new_node->input_pin_ids.size(); ++i) {
+                    int old_pin = old_pins[i].get<int>();
+                    auto [_, inserted] = pin_map.emplace(old_pin, new_node->input_pin_ids[i]);
+                    if (!inserted) {
+                        error = "Graph preset contains duplicate pin id: " + filepath;
+                        std::cerr << error << std::endl;
+                        return false;
+                    }
+                }
+            }
+            if (node_j.contains("output_pin_ids") && node_j["output_pin_ids"].is_array()) {
+                const auto& old_pins = node_j["output_pin_ids"];
+                for (size_t i = 0; i < old_pins.size() && i < new_node->output_pin_ids.size(); ++i) {
+                    int old_pin = old_pins[i].get<int>();
+                    auto [_, inserted] = pin_map.emplace(old_pin, new_node->output_pin_ids[i]);
+                    if (!inserted) {
+                        error = "Graph preset contains duplicate pin id: " + filepath;
+                        std::cerr << error << std::endl;
+                        return false;
+                    }
+                }
+            }
+        }
+
+        for (const auto& link_j : j["links"]) {
+            int old_src = link_j.value("source_pin_id", -1);
+            int old_dst = link_j.value("dest_pin_id", -1);
+            if (pin_map.find(old_src) == pin_map.end() ||
+                pin_map.find(old_dst) == pin_map.end()) {
+                error = "Graph preset link references a missing pin: " + filepath;
+                std::cerr << error << std::endl;
+                return false;
+            }
+
+            if (graph.add_link(pin_map[old_src], pin_map[old_dst]) == -1) {
+                error = "Graph preset contains an invalid link: " + filepath;
+                std::cerr << error << std::endl;
+                return false;
+            }
+        }
+
+        if (!graph.rebuild_topology()) {
+            error = "Graph preset contains an invalid topology: " + filepath;
+            std::cerr << error << std::endl;
+            return false;
+        }
+
+        if (j.contains("input_gain") && j["input_gain"].is_number()) {
+            engine.set_input_gain(j["input_gain"].get<float>());
+        }
+        if (j.contains("output_gain") && j["output_gain"].is_number()) {
+            engine.set_output_gain(j["output_gain"].get<float>());
+        }
+        engine.replace_graph(std::move(graph), std::move(loaded_effects));
+
+        if (midi_manager) {
+            midi_manager->clear_mappings();
+        }
+
+        std::cout << "Graph preset loaded: "
+                  << j.value("name", std::string{"Unnamed Graph Preset"})
+                  << " (" << filepath << ")" << std::endl;
+        return true;
+    } catch (const nlohmann::json::exception& e) {
+        error = "Failed to parse graph preset: " + std::string(e.what());
+        std::cerr << error << std::endl;
+        return false;
+    }
+}
+
+} // namespace
 
 std::vector<std::string> PresetManager::list_presets() {
     std::vector<std::string> result;
@@ -88,6 +266,26 @@ bool PresetManager::load_preset(const std::string& filepath,
     std::string json((std::istreambuf_iterator<char>(file)),
                      std::istreambuf_iterator<char>());
     file.close();
+
+    nlohmann::json parsed = nlohmann::json::parse(json, nullptr, false);
+    bool is_graph_preset = false;
+    if (!parsed.is_discarded()) {
+        is_graph_preset = parsed.contains("nodes") && parsed["nodes"].is_array() &&
+                          parsed.contains("links") && parsed["links"].is_array();
+        if (!is_graph_preset && parsed.contains("format_version") &&
+            parsed["format_version"].is_number_integer()) {
+            is_graph_preset = parsed["format_version"].get<int>() == 2;
+        }
+    }
+    if (is_graph_preset) {
+        std::string graph_error;
+        bool loaded = load_graph_preset(parsed, filepath, engine, midi_manager,
+                                        graph_error);
+        if (!loaded) {
+            last_error_ = graph_error;
+        }
+        return loaded;
+    }
 
     PresetData preset;
     if (!from_json_ext(json, preset)) {

--- a/tests/test_audio_graph.cpp
+++ b/tests/test_audio_graph.cpp
@@ -24,6 +24,9 @@ std::string mock_save_graph(const AudioGraph &graph) {
     node_j["is_graph_output"] = node.is_graph_output;
     node_j["x"] = node.x;
     node_j["y"] = node.y;
+    if (!node.input_gains.empty()) {
+      node_j["input_gains"] = node.input_gains;
+    }
 
     if (node.pedal) {
       node_j["effect"] = node.pedal->get_params();
@@ -115,6 +118,14 @@ bool mock_load_graph(const std::string &json_str, AudioGraph &graph) {
     graph.set_node_as_output(new_id, node_j["is_graph_output"]);
     if (node_j.contains("x") && node_j.contains("y")) {
       graph.set_node_position(new_id, node_j["x"], node_j["y"]);
+    }
+    if (node_j.contains("input_gains") && node_j["input_gains"].is_array()) {
+      for (size_t i = 0; i < node_j["input_gains"].size(); ++i) {
+        if (node_j["input_gains"][i].is_number()) {
+          graph.set_node_input_gain(new_id, i,
+                                    node_j["input_gains"][i].get<float>());
+        }
+      }
     }
 
     const auto *new_node = graph.find_node(new_id);
@@ -243,6 +254,8 @@ TEST(audio_graph_dsp_processing) {
 
   graph.set_node_as_input(p1, true);
   graph.set_node_as_output(m4, true);
+  graph.set_node_input_gain(m4, 0, 1.0f);
+  graph.set_node_input_gain(m4, 1, 1.0f);
 
   auto nodes = graph.get_nodes();
   // P1 -> P2 & P3 (Split)
@@ -271,6 +284,39 @@ TEST(audio_graph_dsp_processing) {
   // M4 receives (P2 + P3) -> (1.0f + 1.0f) = 2.0f.
   // The final output should be strictly 2.0f.
   ASSERT_TRUE(output_audio[0] == 2.0f);
+}
+
+TEST(audio_graph_mixer_input_gains_control_blend) {
+  AudioGraph graph;
+  AudioGraphExecutor executor;
+  executor.prepare(48000, 128);
+
+  int splitter = graph.add_node("Splitter", NodeRoutingType::Splitter);
+  graph.add_node("Path A", NodeRoutingType::StandardEffect);
+  graph.add_node("Path B", NodeRoutingType::StandardEffect);
+  int mixer = graph.add_node("Mixer", NodeRoutingType::Mixer);
+
+  graph.set_node_as_input(splitter, true);
+  graph.set_node_as_output(mixer, true);
+  graph.set_node_input_gain(mixer, 0, 0.25f);
+  graph.set_node_input_gain(mixer, 1, 0.5f);
+
+  auto nodes = graph.get_nodes();
+  graph.add_link(nodes[0].output_pin_ids[0], nodes[1].input_pin_ids[0]);
+  graph.add_link(nodes[0].output_pin_ids[1], nodes[2].input_pin_ids[0]);
+
+  nodes = graph.get_nodes();
+  graph.add_link(nodes[1].output_pin_ids[0], nodes[3].input_pin_ids[0]);
+  graph.add_link(nodes[2].output_pin_ids[0], nodes[3].input_pin_ids[1]);
+
+  ASSERT_TRUE(graph.rebuild_topology());
+  executor.compile(graph);
+
+  std::vector<float> input_audio(64, 1.0f);
+  std::vector<float> output_audio(64, 0.0f);
+  executor.process(input_audio.data(), output_audio.data(), 64);
+
+  ASSERT_TRUE(std::abs(output_audio[0] - 0.75f) < 0.0001f);
 }
 
 // 5. Test Explicit Inputs, Outputs/Sinks, and Silence of Unwired Nodes

--- a/tests/test_preset_manager.cpp
+++ b/tests/test_preset_manager.cpp
@@ -11,6 +11,7 @@
 #include <cstdio>
 #include <cstring>
 #include <filesystem>
+#include <nlohmann/json.hpp>
 
 using namespace Amplitron;
 
@@ -133,6 +134,127 @@ TEST(preset_save_and_load_roundtrip) {
     std::remove(path.c_str());
     engine.shutdown();
     engine2.shutdown();
+}
+
+TEST(preset_load_graph_preserves_parallel_mixer_gains) {
+    const std::string path = "presets/test_graph_parallel_load.json";
+    nlohmann::json graph_preset = {
+        {"format_version", 2},
+        {"name", "Graph Load Test"},
+        {"input_gain", 0.6f},
+        {"output_gain", 0.7f},
+        {"nodes", nlohmann::json::array({
+            {
+                {"id", 1},
+                {"name", "Input"},
+                {"routing_type", static_cast<int>(NodeRoutingType::StandardEffect)},
+                {"is_graph_input", true},
+                {"is_graph_output", false},
+                {"x", 40.0f},
+                {"y", 120.0f},
+                {"input_pin_ids", nlohmann::json::array({2})},
+                {"output_pin_ids", nlohmann::json::array({3})},
+            },
+            {
+                {"id", 4},
+                {"name", "Splitter"},
+                {"routing_type", static_cast<int>(NodeRoutingType::Splitter)},
+                {"is_graph_input", false},
+                {"is_graph_output", false},
+                {"x", 240.0f},
+                {"y", 120.0f},
+                {"input_pin_ids", nlohmann::json::array({5})},
+                {"output_pin_ids", nlohmann::json::array({6, 7})},
+            },
+            {
+                {"id", 8},
+                {"name", "Mixer"},
+                {"routing_type", static_cast<int>(NodeRoutingType::Mixer)},
+                {"is_graph_input", false},
+                {"is_graph_output", true},
+                {"x", 440.0f},
+                {"y", 120.0f},
+                {"input_pin_ids", nlohmann::json::array({9, 10})},
+                {"output_pin_ids", nlohmann::json::array({11})},
+                {"input_gains", nlohmann::json::array({0.5f, 0.5f})},
+            },
+        })},
+        {"links", nlohmann::json::array({
+            {{"id", 12}, {"source_pin_id", 3}, {"dest_pin_id", 5}},
+            {{"id", 13}, {"source_pin_id", 6}, {"dest_pin_id", 9}},
+            {{"id", 14}, {"source_pin_id", 7}, {"dest_pin_id", 10}},
+        })},
+    };
+
+    {
+        std::ofstream out(path);
+        out << graph_preset.dump(2);
+    }
+
+    AudioEngine engine;
+    engine.initialize();
+    ASSERT_TRUE(PresetManager::load_preset(path, engine));
+    ASSERT_NEAR(engine.get_input_gain(), 0.6f, 0.01f);
+    ASSERT_NEAR(engine.get_output_gain(), 0.7f, 0.01f);
+
+    const auto& nodes = engine.graph().get_nodes();
+    ASSERT_EQ(nodes.size(), 3u);
+    ASSERT_EQ(engine.graph().get_links().size(), 3u);
+
+    const DSPNode* mixer = nullptr;
+    for (const auto& node : nodes) {
+        if (node.name == "Mixer") {
+            mixer = &node;
+            break;
+        }
+    }
+
+    ASSERT_TRUE(mixer != nullptr);
+    ASSERT_EQ(mixer->input_gains.size(), 2u);
+    ASSERT_NEAR(mixer->input_gains[0], 0.5f, 0.001f);
+    ASSERT_NEAR(mixer->input_gains[1], 0.5f, 0.001f);
+
+    std::remove(path.c_str());
+    engine.shutdown();
+}
+
+TEST(preset_parallel_amp_blend_example_loads) {
+    AudioEngine engine;
+    engine.initialize();
+
+    ASSERT_TRUE(PresetManager::load_preset("presets/06_Parallel_Amp_Blend.json", engine));
+    ASSERT_EQ(engine.effects().size(), 8u);
+    ASSERT_TRUE(engine.graph().get_nodes().size() >= 12u);
+    ASSERT_EQ(engine.graph().get_links().size(), 12u);
+
+    const DSPNode* mixer = nullptr;
+    const DSPNode* reverb = nullptr;
+    for (const auto& node : engine.graph().get_nodes()) {
+        if (node.name == "Mixer") {
+            mixer = &node;
+        } else if (node.name == "Reverb") {
+            reverb = &node;
+        }
+    }
+
+    ASSERT_TRUE(mixer != nullptr);
+    ASSERT_EQ(mixer->input_gains.size(), 2u);
+    ASSERT_NEAR(mixer->input_gains[0], 0.5f, 0.001f);
+    ASSERT_NEAR(mixer->input_gains[1], 0.5f, 0.001f);
+
+    ASSERT_TRUE(reverb != nullptr);
+    bool mixer_feeds_reverb = false;
+    for (const auto& link : engine.graph().get_links()) {
+        if (!mixer->output_pin_ids.empty() && !reverb->input_pin_ids.empty() &&
+            link.source_pin_id == mixer->output_pin_ids[0] &&
+            link.dest_pin_id == reverb->input_pin_ids[0]) {
+            mixer_feeds_reverb = true;
+            break;
+        }
+    }
+    ASSERT_TRUE(mixer_feeds_reverb);
+
+    engine.shutdown();
 }
 
 TEST(preset_load_nonexistent_fails) {


### PR DESCRIPTION

## What does this PR do?

Adds a new graph-format preset, `06_Parallel_Amp_Blend`, showcasing parallel amp routing with a Splitter and Mixer. The preset blends a dirty British Crunch path with a clean American path at a default 50/50 mix, then sends the merged signal into shared Reverb.

This PR also adds graph preset loading support, Mixer input gain handling, readable saved canvas positions, documentation, and focused tests.

## Related Issue

Fixes #153

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor / code cleanup
- [x] 📝 Documentation
- [x] ✅ Tests
- [ ] 🔧 Build / CI / Configuration

## How Was This Tested?

- Platform(s) tested on: macOS
- Test command run: `python3 -m json.tool presets/06_Parallel_Amp_Blend.json`
- Additional validation:
  - `git diff --check`
  - Custom Python validation for graph node/link references
  - Verified Mixer default gains are `0.5 / 0.5`
  - Verified Mixer feeds shared Reverb after both amp paths merge
- Manual test steps (if applicable):
  - Native app testing was not run locally because `cmake` is not installed in this environment.

## Checklist

- [ ] Code compiles and builds successfully on my platform
- [ ] All existing tests pass (`./amplitron-tests`)
- [x] New tests added for new functionality (if applicable)
- [x] Documentation updated (README, code comments) if applicable
- [x] No blocking calls on the audio thread (no `std::mutex::lock()` on the hot path)
- [x] Tested on: macOS, JSON/static validation only

## Screenshots / Demo

 The UI change adds Mixer A/B gain sliders so users can adjust the clean/dirty blend directly from the Mixer node.
```
<img width="1440" height="900" alt="Screenshot 2026-05-24 at 11 39 41 AM" src="https://github.com/user-attachments/assets/82907e80-b778-4b64-8181-90ff7fb4f9f8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "06 Parallel Amp Blend" preset (parallel dirty/clean amp blend).
  * Mixer nodes expose per-input Blend sliders in the UI with immediate apply.
  * App can load full graph-style presets including per-input gains.

* **UI Improvements**
  * Node positions restored from saved coordinates when available.
  * Output-pin wire controls show only when outputs exist and node isn't the graph output.

* **Documentation**
  * Presets doc updated with preset details, signal-flow diagram, and Blend/Gain tips.

* **Chores**
  * New preset file included.

* **Tests**
  * New tests cover graph preset loading and mixer input-gain blending.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sudip-mondal-2002/Amplitron/pull/214?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->