### PR TITLE
fix(ci): preserve PR preview routes during release deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -360,3 +360,5 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./docs
         publish_branch: gh-pages
+        keep_files: true
+        


### PR DESCRIPTION
## Description
This PR fixes the issue where merging or pushing to the `main` branch unintentionally deletes all active PR preview routes.

### Root Cause
In `.github/workflows/release.yml`, the `deploy-website` job uses `peaceiris/actions-gh-pages` to deploy the site to the `gh-pages` branch. Because the `keep_files: true` flag was missing, the action performed a clean wipe of the branch on every release, which deleted the `pr-previews/` directory managed by the `deploy-preview.yml` workflow.

### Solution
Added `keep_files: true` to the `actions-gh-pages` step in `release.yml`. This ensures that the main deployment only updates the main documentation/website files and preserves the existing PR preview directories.

Fixes #215 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow configuration to preserve existing website files during deployment, ensuring no content is inadvertently removed when publishing updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sudip-mondal-2002/Amplitron/pull/222?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->