### PR TITLE
fix(delay): initialize parameter smoothing states on reset

### DIFF
--- a/src/audio/effects/delay.cpp
+++ b/src/audio/effects/delay.cpp
@@ -65,6 +65,10 @@ void Delay::reset() {
     std::fill(delay_buffer_.begin(), delay_buffer_.end(), 0.0f);
     write_pos_ = 0;
     tone_lp_.reset();
+    smoothed_time_ms_  = params_[0].value;
+    smoothed_feedback_ = params_[1].value;
+    smoothed_tone_     = params_[2].value;
+    smoothed_level_    = params_[3].value;
 }
 
 void Delay::set_transport_state(float bpm){


### PR DESCRIPTION
Closes #250 

## Description: This Pull Request modifies the Delay::reset() implementation to properly initialize the delay parameter smoothing variables (smoothed_time_ms_, smoothed_feedback_, smoothed_tone_, and smoothed_level_) to their current target values.

## Why it's impactful: Solves transient pitch sweeps, feedback buildup, or level clicks in the delay lines during preset loading or transport starts.

## Files Changed: delay.cpp
 - Reset smoothed_time_ms_, smoothed_feedback_, smoothed_tone_, and smoothed_level_ using current target values in reset().

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the delay effect reset behavior to properly initialize from current knob settings instead of relying on previous smoothing state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sudip-mondal-2002/Amplitron/pull/251?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->