### PR TITLE
fix(equalizer): initialize parameter smoothing states on reset

### DIFF
--- a/src/audio/effects/equalizer.cpp
+++ b/src/audio/effects/equalizer.cpp
@@ -72,6 +72,14 @@ void Equalizer::reset() {
     low_shelf_.reset();
     mid_peak_.reset();
     high_shelf_.reset();
+    bass_state_     = params_[0].value;
+    mid_state_      = params_[1].value;
+    treble_state_   = params_[2].value;
+    presence_state_ = params_.size() > 3 ? params_[3].value : 0.0f;
+    cached_bass_     = -999.0f;
+    cached_mid_      = -999.0f;
+    cached_treble_   = -999.0f;
+    cached_presence_ = -999.0f;
 }
 
 } // namespace Amplitron


### PR DESCRIPTION
Closes #252 

## Description: This Pull Request modifies the Equalizer::reset() implementation to properly initialize the EQ frequency band parameter smoothing variables (bass_state_, mid_state_, treble_state_, and presence_state_) to their current target values, and resets the cached parameters to ensure immediate biquad coefficient recomputation.

## Why it's impactful: Eliminates high/low frequency booming or transient swooshes when booting the audio engine or changing presets, ensuring biquads align with user parameters instantly.

## Files Changed: equalizer.cpp
 - Reset bass_state_, mid_state_, treble_state_, and presence_state_ along with cached filter values in reset().