### PR TITLE
fix(chorus): initialize parameter smoothing states on reset

### DIFF
--- a/src/audio/effects/chorus.cpp
+++ b/src/audio/effects/chorus.cpp
@@ -123,6 +123,7 @@ void Chorus::reset() {
     std::fill(delay_buffer_.begin(), delay_buffer_.end(), 0.0f);
     write_pos_ = 0;
     lfo_phase_ = 0.0f;
+    smoothed_rate_ = params_[0].value;
 }
 
 } // namespace Amplitron


### PR DESCRIPTION
Closes #254 

## Description: This Pull Request modifies the Chorus::reset() implementation to properly initialize the LFO rate parameter smoothing variable (smoothed_rate_) to its current target value.

## Why it's impactful: Solves pitch-shifting distortion or warbles when the chorus effect is initialized, bypassed, or during rapid preset switching.

## Files Changed: chorus.cpp
 - Reset smoothed_rate_ using current target values in reset().