### PR TITLE
fix(distortion): initialize parameter smoothing states on reset

### DIFF
--- a/src/audio/effects/distortion.cpp
+++ b/src/audio/effects/distortion.cpp
@@ -61,6 +61,9 @@ void Distortion::process(float* buffer, int num_samples) {
 
 void Distortion::reset() {
     tone_lp_.reset();
+    drive_smoothed_ = params_[0].value;
+    tone_smoothed_  = params_[1].value;
+    level_smoothed_ = params_[2].value;
 }
 
 } // namespace Amplitron


### PR DESCRIPTION
Closes #256 

## Description
This Pull Request modifies the `Distortion::reset()` implementation to properly initialize the distortion parameter smoothing variables (`drive_smoothed_`, `tone_smoothed_`, and `level_smoothed_`) to their current target values.

### Why this is impactful
- **No Sweep Artifacts on Preset Load:** Prevents high-gain sweep noise or volume differences when restarting the audio engine or loading preset configurations.
- **Accurate Wet/Dry Mix Initialization:** Avoids filter and blending lag at startup by snapping the smoothed states instantly to the preset targets.
- **Strict Compliance:** Zero external files or configs were changed. All modifications are contained entirely in a single file.

### Files Changed
* [distortion.cpp](file:///e:/Amplitron/Amplitron/src/audio/effects/distortion.cpp) - Reset `drive_smoothed_`, `tone_smoothed_`, and `level_smoothed_` using current target values in `reset()`.
