### PR TITLE
fix(overdrive): initialize parameter smoothing states on reset

### DIFF
--- a/src/audio/effects/overdrive.cpp
+++ b/src/audio/effects/overdrive.cpp
@@ -53,6 +53,9 @@ void Overdrive::process(float* buffer, int num_samples) {
 void Overdrive::reset() {
     tone_lp_.reset();
     dc_block_.reset();
+    smoothed_drive_ = params_[0].value;
+    smoothed_tone_  = params_[1].value;
+    smoothed_level_ = params_[2].value;
 }
 
 } // namespace Amplitron


### PR DESCRIPTION
Closes #258 

## Description
This Pull Request modifies the `Overdrive::reset()` implementation to properly initialize the overdrive parameter smoothing variables (`smoothed_drive_`, `smoothed_tone_`, and `smoothed_level_`) to their current target values.

### Why this is impactful
- **Clean Patch Recollection:** Eliminates transient saturation sweeps or sudden volume drops when loading overdrive settings or resetting the audio engine.
- **Accurate Envelope Response:** Prevents filter lag and ensures the soft-clipping and low-pass filter coefficients match target presets instantly upon starting the audio backend.
- **Strict Compliance:** Zero external files or configs were changed. All modifications are contained entirely in a single file.

### Files Changed
* [overdrive.cpp](file:///e:/Amplitron/Amplitron/src/audio/effects/overdrive.cpp) - Reset `smoothed_drive_`, `smoothed_tone_`, and `smoothed_level_` using current target values in `reset()`.
