### PR TITLE
fix(compressor): initialize parameter smoothing states on reset

### DIFF
--- a/src/audio/effects/compressor.cpp
+++ b/src/audio/effects/compressor.cpp
@@ -47,6 +47,8 @@ void Compressor::process(float* buffer, int num_samples) {
 
 void Compressor::reset() {
     env_.reset();
+    smoothed_attack_ms_ = params_[2].value;
+    smoothed_release_ms_ = params_[3].value;
 }
 
 } // namespace Amplitron


### PR DESCRIPTION
Closes #250 

## Description
This Pull Request modifies the `Compressor::reset()` implementation to correctly initialize parameter smoothing state variables (`smoothed_attack_ms_` and `smoothed_release_ms_`) directly to their corresponding target values.

### Why this is impactful
- **Glitch-Free Patch Changing:** Prevents sudden volume spikes, clicks, or dynamic pumping when resetting the audio pipeline or switching between presets that have different compressor attack/release values.
- **Improved Audio Stability:** Ensures the compressor begins processing with accurate time coefficients immediately instead of lagging behind target preset parameters.
- **Strict Compliance:** Zero external files or configs were changed. All modifications are contained entirely in a single file.

### Files Changed
* [compressor.cpp](file:///e:/Amplitron/Amplitron/src/audio/effects/compressor.cpp) - Reset `smoothed_attack_ms_` and `smoothed_release_ms_` using current target values in `reset()`.
