### PR TITLE
feat(gui): replace pixelated learn emoji with clean text label

### DIFF
--- a/src/gui/pedal_board_menu.cpp
+++ b/src/gui/pedal_board_menu.cpp
@@ -188,7 +188,7 @@ void PedalBoard::render_midi_menu() {
 
         // Learn mode status
         if (midi.is_learning()) {
-            ImGui::TextColored(ImVec4(1.0f, 0.8f, 0.0f, 1.0f), "⚡ Learn Mode Active");
+            ImGui::TextColored(ImVec4(1.0f, 0.8f, 0.0f, 1.0f), "[MIDI LEARN ACTIVE]");
             if (ImGui::MenuItem("Cancel Learn Mode", "Esc")) {
                 midi.cancel_learn();
             }


### PR DESCRIPTION
Closes #262 

### Description
This Pull Request replaces the platform-dependent, pixelated ⚡ emoji inside the Dear ImGui MIDI Learn Mode active label with a highly readable, standardized bracketed text flag: [MIDI LEARN ACTIVE].

### Why this is impactful
Universal Font Support: Dear ImGui fonts in native builds often lack complete unicode emoji blocks, resulting in ugly question mark boxes [?] or pixelated graphics on many devices.
### Professional Aesthetics: Standardizes text branding to brackets, matching standard audio hardware indicators (e.g. [MUTED], [LEARNING]).
Strict Compliance: Zero external files, styling frameworks, or configs were changed. All modifications are contained entirely in a single file: src/gui/pedal_board_menu.cpp.

### Files Changed: pedal_board_menu.cpp
 - Replaced ⚡ Learn Mode Active with [MIDI LEARN ACTIVE] in the popup status.