### PR TITLE
fix(wah): initialize parameter smoothing states on reset

### DIFF
--- a/src/audio/effects/wah.cpp
+++ b/src/audio/effects/wah.cpp
@@ -77,8 +77,8 @@ void WahPedal::reset() {
     svf_lp_       = 0.0f;
     svf_bp_       = 0.0f;
     env_.reset();
-    sweep_smooth_ = 0.5f;
-    q_smooth_     = 3.5f;
+    sweep_smooth_ = params_[1].value;
+    q_smooth_     = params_[2].value;
 }
 
 } // namespace Amplitron


### PR DESCRIPTION
Closes #266 

### Description: This Pull Request modifies the WahPedal::reset() implementation to properly initialize the resonant wah pedal sweep and Q parameter smoothing variables (sweep_smooth_ and q_smooth_) to their current target values.

### Why it's impactful: Prevents high-Q resonant sweeping squeals or filter zipper noises when engaging or resetting the wah effect.

### Files Changed: 
wah.cpp
 - Reset sweep_smooth_ and q_smooth_ using current target values in reset().