### PR TITLE
fix(looper): zero out loop buffers on reset

### DIFF
--- a/src/audio/effects/looper.cpp
+++ b/src/audio/effects/looper.cpp
@@ -47,6 +47,8 @@ void Looper::reset() {
     loop_length_ = 0;
     loop_level_smoothed_ = clamp(params_[0].value, 0.0f, 1.0f);
     crossfade_ms_smoothed_ = clamp(params_[1].value, 0.0f, 20.0f);
+    std::fill(buffer_l_.begin(), buffer_l_.end(), 0.0f);
+    std::fill(buffer_r_.begin(), buffer_r_.end(), 0.0f);
     pending_commands_.store(0, std::memory_order_relaxed);
     publish_ui_snapshot();
 }


### PR DESCRIPTION
Closes #268 

### Description: This Pull Request modifies the Looper::reset() implementation to fully zero out the internal left and right channel loop recording buffers (buffer_l_ and buffer_r_) using std::fill with 0.0f.

### Why it's impactful: Prevents old loop recording audio fragments or residues from playing back when starting a clean looper session.

### Files Changed: 
looper.cpp
 - Zero out loop buffers buffer_l_ and buffer_r_ using std::fill on reset().