### PR TITLE
feat: implement N-input dynamic mixer with per-channel gain routing

### DIFF
--- a/src/audio/engine/audio_engine.h
+++ b/src/audio/engine/audio_engine.h
@@ -259,6 +259,14 @@ public:
     void push_param_change(int effect_index, int param_index, float value);
 
     /**
+     * @brief Enqueue a mixer input gain change from the GUI thread.
+     * @param node_id      ID of the Mixer node.
+     * @param pin_index    Index of the input pin on the mixer.
+     * @param gain         New gain multiplier (0.0–2.0).
+     */
+    void push_mixer_gain_change(int node_id, int pin_index, float gain);
+
+    /**
      * @brief Enqueue an effect enabled/disabled change from the GUI thread.
      * @param effect_index Index of the effect in the chain.
      * @param enabled      >0.5 means enabled.

--- a/src/audio/engine/audio_engine_api.cpp
+++ b/src/audio/engine/audio_engine_api.cpp
@@ -60,6 +60,15 @@ void AudioEngine::push_effect_mix(int effect_index, float mix) {
     command_queue_.try_push(cmd);
 }
 
+void AudioEngine::push_mixer_gain_change(int node_id, int pin_index, float gain) {
+    AudioCommand cmd{};
+    cmd.type = AudioCommand::SetMixerGain;
+    cmd.effect_index = node_id; // Overload effect_index to mean node_id
+    cmd.param_index = pin_index; // Overload param_index to mean pin_index
+    cmd.value = gain;
+    command_queue_.try_push(cmd);
+}
+
 int AudioEngine::get_suggested_buffer_size() const {
     float load = cpu_load_.load(std::memory_order_relaxed);
     int current = buffer_size_;

--- a/src/audio/engine/audio_engine_process.cpp
+++ b/src/audio/engine/audio_engine_process.cpp
@@ -291,6 +291,12 @@ void AudioEngine::drain_commands() {
                 }
                 break;
             }
+            case AudioCommand::SetMixerGain: {
+                if (audio_shadow_executor_) {
+                    audio_shadow_executor_->update_mixer_gain(cmd.effect_index, cmd.param_index, cmd.value);
+                }
+                break;
+            }
             case AudioCommand::SetInputGain:
                 input_gain_.store(cmd.value, std::memory_order_relaxed);
                 break;

--- a/src/audio/engine/audio_engine_process.cpp
+++ b/src/audio/engine/audio_engine_process.cpp
@@ -250,6 +250,11 @@ void AudioEngine::drain_gain_commands() {
         } else if (cmd.type == AudioCommand::SetOutputGain) {
             command_queue_.try_pop(cmd);
             output_gain_.store(cmd.value, std::memory_order_relaxed);
+        } else if (cmd.type == AudioCommand::SetMixerGain) {
+            command_queue_.try_pop(cmd);
+            if (audio_shadow_executor_) {
+                audio_shadow_executor_->update_mixer_gain(cmd.effect_index, cmd.param_index, cmd.value);
+            }
         } else {
             break;
         }
@@ -291,12 +296,9 @@ void AudioEngine::drain_commands() {
                 }
                 break;
             }
-            case AudioCommand::SetMixerGain: {
-                if (audio_shadow_executor_) {
-                    audio_shadow_executor_->update_mixer_gain(cmd.effect_index, cmd.param_index, cmd.value);
-                }
+            case AudioCommand::SetMixerGain:
+                // Skip SetMixerGain in the mutex-gated path, it is handled lock-free
                 break;
-            }
             case AudioCommand::SetInputGain:
                 input_gain_.store(cmd.value, std::memory_order_relaxed);
                 break;

--- a/src/audio/engine/audio_graph.cpp
+++ b/src/audio/engine/audio_graph.cpp
@@ -358,25 +358,54 @@ bool AudioGraph::add_input_pin(int node_id) {
   return false;
 }
 
-bool AudioGraph::remove_input_pin(int node_id) {
+bool AudioGraph::remove_input_pin(int node_id, int pin_id) {
   for (auto &node : nodes_) {
-    if (node.id == node_id && node.routing_type == NodeRoutingType::Mixer) {
+    if (node.id == node_id && (node.routing_type == NodeRoutingType::Mixer || node.routing_type == NodeRoutingType::MergeSum)) {
       if (node.input_pin_ids.size() > 2) {
-        int pin_to_remove = node.input_pin_ids.back();
-        // Prevent removal if the pin is linked
-        for (const auto &link : links_) {
-          if (link.dest_pin_id == pin_to_remove) {
-            return false;
-          }
+        int index_to_remove = -1;
+        if (pin_id == -1) {
+           index_to_remove = node.input_pin_ids.size() - 1;
+        } else {
+           for (size_t i = 0; i < node.input_pin_ids.size(); ++i) {
+               if (node.input_pin_ids[i] == pin_id) {
+                   index_to_remove = i;
+                   break;
+               }
+           }
         }
-        node.input_pin_ids.pop_back();
-        node.input_gains.pop_back();
-        return true;
+        if (index_to_remove != -1) {
+            int pin_to_remove = node.input_pin_ids[index_to_remove];
+            // Prevent removal if the pin is linked
+            for (const auto &link : links_) {
+              if (link.dest_pin_id == pin_to_remove) {
+                return false;
+              }
+            }
+            node.input_pin_ids.erase(node.input_pin_ids.begin() + index_to_remove);
+            node.input_gains.erase(node.input_gains.begin() + index_to_remove);
+            return true;
+        }
       }
       return false;
     }
   }
   return false;
+}
+
+void AudioGraph::restore_input_pin(int node_id, int pin_id, int index, float gain) {
+  for (auto &node : nodes_) {
+    if (node.id == node_id) {
+        if (index >= 0 && index <= node.input_pin_ids.size()) {
+            node.input_pin_ids.insert(node.input_pin_ids.begin() + index, pin_id);
+            node.input_gains.insert(node.input_gains.begin() + index, gain);
+        } else {
+            node.input_pin_ids.push_back(pin_id);
+            node.input_gains.push_back(gain);
+        }
+        if (pin_id >= next_id_) next_id_ = pin_id + 1;
+        break;
+    }
+  }
 }
 
 void AudioGraph::set_mixer_input_gain(int node_id, size_t pin_index, float gain) {

--- a/src/audio/engine/audio_graph.cpp
+++ b/src/audio/engine/audio_graph.cpp
@@ -19,6 +19,7 @@ int AudioGraph::add_node(const std::string &name, NodeRoutingType type,
     for (int i = 0; i < inputs_to_create; ++i) {
       node.input_pin_ids.push_back(next_id_++);
     }
+    node.input_gains.assign(inputs_to_create, 1.0f);
     node.output_pin_ids.push_back(next_id_++); // 1 Output Pin
   } else if (type == NodeRoutingType::Splitter) {
     node.input_pin_ids.push_back(next_id_++);  // 1 Input Pin
@@ -342,6 +343,51 @@ void AudioGraph::restore_link(const GraphLink& link) {
       rebuild_topology();
   }
 }
+bool AudioGraph::add_input_pin(int node_id) {
+  for (auto &node : nodes_) {
+    if (node.id == node_id && node.routing_type == NodeRoutingType::Mixer) {
+      if (node.input_pin_ids.size() < 8) {
+        node.input_pin_ids.push_back(next_id_++);
+        node.input_gains.push_back(1.0f);
+        // Do not necessarily need to rebuild topology if we just added an unconnected pin
+        return true;
+      }
+      return false;
+    }
+  }
+  return false;
+}
 
+bool AudioGraph::remove_input_pin(int node_id) {
+  for (auto &node : nodes_) {
+    if (node.id == node_id && node.routing_type == NodeRoutingType::Mixer) {
+      if (node.input_pin_ids.size() > 2) {
+        int pin_to_remove = node.input_pin_ids.back();
+        // Prevent removal if the pin is linked
+        for (const auto &link : links_) {
+          if (link.dest_pin_id == pin_to_remove) {
+            return false;
+          }
+        }
+        node.input_pin_ids.pop_back();
+        node.input_gains.pop_back();
+        return true;
+      }
+      return false;
+    }
+  }
+  return false;
+}
+
+void AudioGraph::set_mixer_input_gain(int node_id, size_t pin_index, float gain) {
+  for (auto &node : nodes_) {
+    if (node.id == node_id && node.routing_type == NodeRoutingType::Mixer) {
+      if (pin_index < node.input_gains.size()) {
+        node.input_gains[pin_index] = std::clamp(gain, 0.0f, 2.0f);
+      }
+      break;
+    }
+  }
+}
 
 } // namespace Amplitron

--- a/src/audio/engine/audio_graph.cpp
+++ b/src/audio/engine/audio_graph.cpp
@@ -398,9 +398,18 @@ bool AudioGraph::remove_input_pin(int node_id, int pin_id) {
 void AudioGraph::restore_input_pin(int node_id, int pin_id, int index, float gain) {
   for (auto &node : nodes_) {
     if (node.id == node_id) {
-        if (index >= 0 && index <= node.input_pin_ids.size()) {
-            node.input_pin_ids.insert(node.input_pin_ids.begin() + index, pin_id);
-            node.input_gains.insert(node.input_gains.begin() + index, gain);
+        if (index >= 0) {
+            size_t idx = static_cast<size_t>(index);
+            if (idx <= node.input_pin_ids.size()) {
+                node.input_pin_ids.insert(node.input_pin_ids.begin() + idx, pin_id);
+                while (node.input_gains.size() < idx) {
+                    node.input_gains.push_back(1.0f);
+                }
+                node.input_gains.insert(node.input_gains.begin() + idx, gain);
+            } else {
+                node.input_pin_ids.push_back(pin_id);
+                node.input_gains.push_back(gain);
+            }
         } else {
             node.input_pin_ids.push_back(pin_id);
             node.input_gains.push_back(gain);
@@ -418,6 +427,65 @@ void AudioGraph::set_mixer_input_gain(int node_id, size_t pin_index, float gain)
         node.input_gains[pin_index] = std::clamp(gain, 0.0f, 2.0f);
       }
       break;
+    }
+  }
+}
+
+bool AudioGraph::add_output_pin(int node_id) {
+  for (auto &node : nodes_) {
+    if (node.id == node_id && node.routing_type == NodeRoutingType::Splitter) {
+      if (node.output_pin_ids.size() < 8) {
+        node.output_pin_ids.push_back(next_id_++);
+        return true;
+      }
+      return false;
+    }
+  }
+  return false;
+}
+
+bool AudioGraph::remove_output_pin(int node_id, int pin_id) {
+  for (auto &node : nodes_) {
+    if (node.id == node_id && node.routing_type == NodeRoutingType::Splitter) {
+      if (node.output_pin_ids.size() > 2) {
+        int index_to_remove = -1;
+        if (pin_id == -1) {
+           index_to_remove = node.output_pin_ids.size() - 1;
+        } else {
+           for (size_t i = 0; i < node.output_pin_ids.size(); ++i) {
+               if (node.output_pin_ids[i] == pin_id) {
+                   index_to_remove = i;
+                   break;
+               }
+           }
+        }
+        if (index_to_remove != -1) {
+            int pin_to_remove = node.output_pin_ids[index_to_remove];
+            for (const auto &link : links_) {
+              if (link.source_pin_id == pin_to_remove) {
+                return false;
+              }
+            }
+            node.output_pin_ids.erase(node.output_pin_ids.begin() + index_to_remove);
+            return true;
+        }
+      }
+      return false;
+    }
+  }
+  return false;
+}
+
+void AudioGraph::restore_output_pin(int node_id, int pin_id, int index) {
+  for (auto &node : nodes_) {
+    if (node.id == node_id && node.routing_type == NodeRoutingType::Splitter) {
+        if (index >= 0 && index <= node.output_pin_ids.size()) {
+            node.output_pin_ids.insert(node.output_pin_ids.begin() + index, pin_id);
+        } else {
+            node.output_pin_ids.push_back(pin_id);
+        }
+        if (pin_id >= next_id_) next_id_ = pin_id + 1;
+        break;
     }
   }
 }

--- a/src/audio/engine/audio_graph.cpp
+++ b/src/audio/engine/audio_graph.cpp
@@ -15,7 +15,7 @@ int AudioGraph::add_node(const std::string &name, NodeRoutingType type,
 
   // Dynamically configure pin structures using the same unified ID pool
   if (type == NodeRoutingType::Mixer || type == NodeRoutingType::MergeSum) {
-    int inputs_to_create = (num_inputs > 0) ? num_inputs : 2;
+    int inputs_to_create = std::clamp((num_inputs > 0) ? num_inputs : 2, 2, 8);
     for (int i = 0; i < inputs_to_create; ++i) {
       node.input_pin_ids.push_back(next_id_++);
     }
@@ -362,6 +362,9 @@ bool AudioGraph::remove_input_pin(int node_id, int pin_id) {
   for (auto &node : nodes_) {
     if (node.id == node_id && (node.routing_type == NodeRoutingType::Mixer || node.routing_type == NodeRoutingType::MergeSum)) {
       if (node.input_pin_ids.size() > 2) {
+        if (node.input_gains.size() < node.input_pin_ids.size()) {
+            node.input_gains.resize(node.input_pin_ids.size(), 1.0f);
+        }
         int index_to_remove = -1;
         if (pin_id == -1) {
            index_to_remove = node.input_pin_ids.size() - 1;

--- a/src/audio/engine/audio_graph.h
+++ b/src/audio/engine/audio_graph.h
@@ -31,6 +31,8 @@ struct DSPNode {
 
   float x = 0.0f;
   float y = 0.0f;
+
+  std::vector<float> input_gains; // Gain for each input pin (Mixer only)
 };
 
 struct GraphLink {
@@ -61,6 +63,11 @@ public:
   // For Undo/Redo System (forces cache reload)
   void restore_node(const DSPNode& node);
   void restore_link(const GraphLink& link);
+
+  // Dynamic Mixer API
+  bool add_input_pin(int node_id);
+  bool remove_input_pin(int node_id);
+  void set_mixer_input_gain(int node_id, size_t pin_index, float gain);
 
   // Accessors
   const std::vector<int> &get_sorted_nodes() const { return sorted_node_ids_; }

--- a/src/audio/engine/audio_graph.h
+++ b/src/audio/engine/audio_graph.h
@@ -66,8 +66,9 @@ public:
 
   // Dynamic Mixer API
   bool add_input_pin(int node_id);
-  bool remove_input_pin(int node_id);
+  bool remove_input_pin(int node_id, int pin_id = -1);
   void set_mixer_input_gain(int node_id, size_t pin_index, float gain);
+  void restore_input_pin(int node_id, int pin_id, int index, float gain);
 
   // Accessors
   const std::vector<int> &get_sorted_nodes() const { return sorted_node_ids_; }

--- a/src/audio/engine/audio_graph.h
+++ b/src/audio/engine/audio_graph.h
@@ -70,6 +70,11 @@ public:
   void set_mixer_input_gain(int node_id, size_t pin_index, float gain);
   void restore_input_pin(int node_id, int pin_id, int index, float gain);
 
+  // Dynamic Splitter API
+  bool add_output_pin(int node_id);
+  bool remove_output_pin(int node_id, int pin_id = -1);
+  void restore_output_pin(int node_id, int pin_id, int index);
+
   // Accessors
   const std::vector<int> &get_sorted_nodes() const { return sorted_node_ids_; }
   const std::vector<DSPNode> &get_nodes() const { return nodes_; }

--- a/src/audio/engine/audio_graph_executor.cpp
+++ b/src/audio/engine/audio_graph_executor.cpp
@@ -78,12 +78,17 @@ void AudioGraphExecutor::compile(const AudioGraph& graph) {
         }
 
         // Trace upstream connections to find which buffers to read from
-        for (int in_pin : it->input_pin_ids) {
+        for (size_t pin_idx = 0; pin_idx < it->input_pin_ids.size(); ++pin_idx) {
+            int in_pin = it->input_pin_ids[pin_idx];
+            float pin_gain = 1.0f;
+            if (pin_idx < it->input_gains.size()) {
+                pin_gain = it->input_gains[pin_idx];
+            }
             for (const auto& link : links) {
                 if (link.dest_pin_id == in_pin) {
                     int src_node_id = graph.get_node_from_pin(link.source_pin_id);
                     if (src_node_id != -1 && node_to_buffer.count(src_node_id)) {
-                        step.input_sources.push_back({ node_to_buffer[src_node_id] });
+                        step.input_sources.push_back({ node_to_buffer[src_node_id], pin_gain, static_cast<int>(pin_idx) });
                     }
                 }
             }
@@ -128,8 +133,14 @@ void AudioGraphExecutor::process(const float* input, float* output, int num_samp
             std::memset(node_input, 0, num_samples * sizeof(float));
             for (const auto& src : step.input_sources) {
                 const float* src_buf = buffer_pool_[src.buffer_index].data();
-                for (int i = 0; i < num_samples; ++i) {
-                    node_input[i] += src_buf[i];
+                if (src.gain == 1.0f) {
+                    for (int i = 0; i < num_samples; ++i) {
+                        node_input[i] += src_buf[i];
+                    }
+                } else {
+                    for (int i = 0; i < num_samples; ++i) {
+                        node_input[i] += src_buf[i] * src.gain;
+                    }
                 }
             }
         }
@@ -157,6 +168,19 @@ void AudioGraphExecutor::process(const float* input, float* output, int num_samp
             for (int i = 0; i < num_samples; ++i) {
                 output[i] += sink_buf[i];
             }
+        }
+    }
+}
+
+void AudioGraphExecutor::update_mixer_gain(int node_id, int pin_index, float gain) {
+    for (auto& step : execution_plan_) {
+        if (step.node_id == node_id) {
+            for (auto& src : step.input_sources) {
+                if (src.pin_index == pin_index) {
+                    src.gain = gain;
+                }
+            }
+            break;
         }
     }
 }

--- a/src/audio/engine/audio_graph_executor.cpp
+++ b/src/audio/engine/audio_graph_executor.cpp
@@ -174,10 +174,11 @@ void AudioGraphExecutor::process(const float* input, float* output, int num_samp
 
 void AudioGraphExecutor::update_mixer_gain(int node_id, int pin_index, float gain) {
     for (auto& step : execution_plan_) {
-        if (step.node_id == node_id) {
+        if (step.node_id == node_id && (step.type == NodeRoutingType::Mixer || step.type == NodeRoutingType::MergeSum)) {
             for (auto& src : step.input_sources) {
                 if (src.pin_index == pin_index) {
-                    src.gain = gain;
+                    src.gain = std::clamp(gain, 0.0f, 2.0f);
+                    break;
                 }
             }
             break;

--- a/src/audio/engine/audio_graph_executor.h
+++ b/src/audio/engine/audio_graph_executor.h
@@ -26,6 +26,7 @@ public:
     // Hot-path processing (Strictly allocation-free and lock-free)
     // Adjust the pedal->process signature if your pedals process strictly in-place
     void process(const float* input, float* output, int num_samples);
+    void update_mixer_gain(int node_id, int pin_index, float gain);
 
 private:
     int sample_rate_ = 48000;
@@ -34,6 +35,8 @@ private:
 
     struct InputSource {
         int buffer_index; // The pool index to read from
+        float gain = 1.0f;
+        int pin_index = 0;
     };
 
     struct NodeExecutionStep {

--- a/src/audio/utils/spsc_queue.h
+++ b/src/audio/utils/spsc_queue.h
@@ -89,6 +89,7 @@ struct AudioCommand {
         SetEffectParam,      // Change an effect parameter value
         SetEffectEnabled,    // Enable/disable an effect
         SetEffectMix,        // Change effect wet/dry mix
+        SetMixerGain,        // Change mixer input gain dynamically
         SetInputGain,        // Change master input gain
         SetOutputGain,       // Change master output gain
         AddEffect,           // Signal that effect list changed (swap pointer)

--- a/src/gui/commands/command_graph.h
+++ b/src/gui/commands/command_graph.h
@@ -52,6 +52,13 @@ struct AddGraphNodeCommand : public Command {
     const char* description() const override { return "Add Node"; }
 };
 
+struct RemovedPinInfo {
+    int node_id;
+    int pin_id;
+    int index;
+    float gain;
+};
+
 struct RemoveGraphNodeCommand : public Command {
     AudioEngine& engine_;
     NodeId node_id;
@@ -59,6 +66,7 @@ struct RemoveGraphNodeCommand : public Command {
     ImVec2 position;
     std::vector<GraphLink> severed_links; // cache for undo
     DSPNode cached_node;                  // full node data for exact restoration
+    std::vector<RemovedPinInfo> auto_removed_pins; // cache for dynamically removed pins on other nodes
 
     RemoveGraphNodeCommand(AudioEngine& engine, NodeId id, EffectType t, ImVec2 pos)
         : engine_(engine), node_id(id), type(t), position(pos) {}
@@ -80,6 +88,28 @@ struct RemoveGraphNodeCommand : public Command {
 
         engine_.graph().remove_node(node_id);
         GuiGraphState::get_instance().node_positions.erase(node_id);
+        
+        // Clean up empty pins on mixers that were affected by severed links
+        for (const auto& link : severed_links) {
+            int dest_node_id = engine_.graph().get_node_from_pin(link.dest_pin_id);
+            if (dest_node_id != -1) {
+                const DSPNode* n = engine_.graph().find_node(dest_node_id);
+                if (n && (n->routing_type == NodeRoutingType::Mixer || n->routing_type == NodeRoutingType::MergeSum)) {
+                    if (n->input_pin_ids.size() > 2) {
+                        int idx = -1; float gain = 1.0f;
+                        for (size_t i = 0; i < n->input_pin_ids.size(); ++i) {
+                            if (n->input_pin_ids[i] == link.dest_pin_id) {
+                                idx = i; gain = n->input_gains[i]; break;
+                            }
+                        }
+                        if (engine_.graph().remove_input_pin(dest_node_id, link.dest_pin_id)) {
+                            auto_removed_pins.push_back({dest_node_id, link.dest_pin_id, idx, gain});
+                        }
+                    }
+                }
+            }
+        }
+
         engine_.commit_graph_changes();
         return true;
     }
@@ -88,6 +118,9 @@ struct RemoveGraphNodeCommand : public Command {
         engine_.graph().restore_node(cached_node);
         GuiGraphState::get_instance().node_positions[node_id] = { position, false, ImVec2(0, 0) };
         
+        for (auto it = auto_removed_pins.rbegin(); it != auto_removed_pins.rend(); ++it) {
+            engine_.graph().restore_input_pin(it->node_id, it->pin_id, it->index, it->gain);
+        }
         for (const auto& link : severed_links) {
             engine_.graph().restore_link(link);
         }
@@ -101,6 +134,11 @@ struct AddGraphLinkCommand : public Command {
     AudioEngine& engine_;
     GraphLink link;
     bool was_successful = false;
+    
+    int auto_added_pin_node_id = -1;
+    int auto_added_pin_id = -1;
+    int auto_added_pin_index = -1;
+    float auto_added_pin_gain = 1.0f;
 
     AddGraphLinkCommand(AudioEngine& engine, int src_pin, int dst_pin)
         : engine_(engine) {
@@ -122,7 +160,38 @@ struct AddGraphLinkCommand : public Command {
 
             link.id = engine_.graph().add_link(link.source_pin_id, link.dest_pin_id);
             was_successful = (link.id != -1);
+            
+            if (was_successful) {
+                int dest_node_id = engine_.graph().get_node_from_pin(link.dest_pin_id);
+                if (dest_node_id != -1) {
+                    const DSPNode* node = engine_.graph().find_node(dest_node_id);
+                    if (node && (node->routing_type == NodeRoutingType::Mixer || node->routing_type == NodeRoutingType::MergeSum)) {
+                        int occupied_count = 0;
+                        for (int p : node->input_pin_ids) {
+                            for (const auto& l : engine_.graph().get_links()) {
+                                if (l.dest_pin_id == p) {
+                                    occupied_count++; break;
+                                }
+                            }
+                        }
+                        if (occupied_count == node->input_pin_ids.size()) {
+                            if (engine_.graph().add_input_pin(dest_node_id)) {
+                                const DSPNode* updated_node = engine_.graph().find_node(dest_node_id);
+                                int new_pin = updated_node->input_pin_ids.back();
+                                
+                                auto_added_pin_node_id = dest_node_id;
+                                auto_added_pin_id = new_pin;
+                                auto_added_pin_index = updated_node->input_pin_ids.size() - 1;
+                                auto_added_pin_gain = 1.0f;
+                            }
+                        }
+                    }
+                }
+            }
         } else if (was_successful) {
+            if (auto_added_pin_node_id != -1) {
+                engine_.graph().restore_input_pin(auto_added_pin_node_id, auto_added_pin_id, auto_added_pin_index, auto_added_pin_gain);
+            }
             engine_.graph().restore_link(link);
         }
         if (was_successful) {
@@ -134,6 +203,9 @@ struct AddGraphLinkCommand : public Command {
     void undo() override {
         if (was_successful) {
             engine_.graph().remove_link(link.id);
+            if (auto_added_pin_node_id != -1) {
+                engine_.graph().remove_input_pin(auto_added_pin_node_id, auto_added_pin_id);
+            }
             engine_.commit_graph_changes();
         }
     }
@@ -144,6 +216,11 @@ struct AddGraphLinkCommand : public Command {
 struct RemoveGraphLinkCommand : public Command {
     AudioEngine& engine_;
     GraphLink link;
+    
+    int auto_removed_pin_node_id = -1;
+    int auto_removed_pin_id = -1;
+    int auto_removed_pin_index = -1;
+    float auto_removed_pin_gain = 1.0f;
 
     RemoveGraphLinkCommand(AudioEngine& engine, const GraphLink& l)
         : engine_(engine), link(l) {}
@@ -151,12 +228,34 @@ struct RemoveGraphLinkCommand : public Command {
     bool execute() override {
         bool success = engine_.graph().remove_link(link.id);
         if (success) {
+            int dest_node_id = engine_.graph().get_node_from_pin(link.dest_pin_id);
+            if (dest_node_id != -1) {
+                const DSPNode* node = engine_.graph().find_node(dest_node_id);
+                if (node && (node->routing_type == NodeRoutingType::Mixer || node->routing_type == NodeRoutingType::MergeSum)) {
+                    if (node->input_pin_ids.size() > 2) {
+                        for (size_t i = 0; i < node->input_pin_ids.size(); ++i) {
+                            if (node->input_pin_ids[i] == link.dest_pin_id) {
+                                auto_removed_pin_index = i;
+                                auto_removed_pin_gain = node->input_gains[i];
+                                break;
+                            }
+                        }
+                        if (engine_.graph().remove_input_pin(dest_node_id, link.dest_pin_id)) {
+                            auto_removed_pin_node_id = dest_node_id;
+                            auto_removed_pin_id = link.dest_pin_id;
+                        }
+                    }
+                }
+            }
             engine_.commit_graph_changes();
         }
         return success;
     }
 
     void undo() override {
+        if (auto_removed_pin_node_id != -1) {
+            engine_.graph().restore_input_pin(auto_removed_pin_node_id, auto_removed_pin_id, auto_removed_pin_index, auto_removed_pin_gain);
+        }
         engine_.graph().restore_link(link);
         engine_.commit_graph_changes();
     }

--- a/src/gui/commands/command_graph.h
+++ b/src/gui/commands/command_graph.h
@@ -19,12 +19,14 @@ struct AddGraphNodeCommand : public Command {
     ImVec2 position;
     DSPNode cached_node; // To remember exactly what was added for redo
 
-    AddGraphNodeCommand(AudioEngine& engine, const std::string& name, EffectType type, std::shared_ptr<Effect> pedal, ImVec2 pos)
-        : engine_(engine), name(name), type(type), pedal(pedal), position(pos) {}
+    int num_inputs = 0;
+
+    AddGraphNodeCommand(AudioEngine& engine, const std::string& name, EffectType type, std::shared_ptr<Effect> pedal, ImVec2 pos, int num_inputs = 0)
+        : engine_(engine), name(name), type(type), pedal(pedal), position(pos), num_inputs(num_inputs) {}
 
     bool execute() override {
         if (node_id == -1) {
-            node_id = engine_.graph().add_node(name, type, pedal);
+            node_id = engine_.graph().add_node(name, type, pedal, num_inputs);
             auto* added_node = engine_.graph().find_node(node_id);
             if (added_node) cached_node = *added_node;
         } else {

--- a/src/gui/commands/command_graph.h
+++ b/src/gui/commands/command_graph.h
@@ -192,7 +192,7 @@ struct AddGraphLinkCommand : public Command {
                 if (dest_node_id != -1) {
                     const DSPNode* node = engine_.graph().find_node(dest_node_id);
                     if (node && (node->routing_type == NodeRoutingType::Mixer || node->routing_type == NodeRoutingType::MergeSum)) {
-                        int occupied_count = 0;
+                        size_t occupied_count = 0;
                         for (int p : node->input_pin_ids) {
                             for (const auto& l : engine_.graph().get_links()) {
                                 if (l.dest_pin_id == p) {
@@ -218,7 +218,7 @@ struct AddGraphLinkCommand : public Command {
                 if (source_node_id != -1) {
                     const DSPNode* node = engine_.graph().find_node(source_node_id);
                     if (node && node->routing_type == NodeRoutingType::Splitter) {
-                        int occupied_count = 0;
+                        size_t occupied_count = 0;
                         for (int p : node->output_pin_ids) {
                             for (const auto& l : engine_.graph().get_links()) {
                                 if (l.source_pin_id == p) {

--- a/src/gui/commands/command_graph.h
+++ b/src/gui/commands/command_graph.h
@@ -67,6 +67,7 @@ struct RemoveGraphNodeCommand : public Command {
     std::vector<GraphLink> severed_links; // cache for undo
     DSPNode cached_node;                  // full node data for exact restoration
     std::vector<RemovedPinInfo> auto_removed_pins; // cache for dynamically removed pins on other nodes
+    std::vector<RemovedPinInfo> auto_removed_out_pins;
 
     RemoveGraphNodeCommand(AudioEngine& engine, NodeId id, EffectType t, ImVec2 pos)
         : engine_(engine), node_id(id), type(t), position(pos) {}
@@ -99,11 +100,29 @@ struct RemoveGraphNodeCommand : public Command {
                         int idx = -1; float gain = 1.0f;
                         for (size_t i = 0; i < n->input_pin_ids.size(); ++i) {
                             if (n->input_pin_ids[i] == link.dest_pin_id) {
-                                idx = i; gain = n->input_gains[i]; break;
+                                idx = i; gain = (i < n->input_gains.size()) ? n->input_gains[i] : 1.0f; break;
                             }
                         }
                         if (engine_.graph().remove_input_pin(dest_node_id, link.dest_pin_id)) {
                             auto_removed_pins.push_back({dest_node_id, link.dest_pin_id, idx, gain});
+                        }
+                    }
+                }
+            }
+
+            int source_node_id = engine_.graph().get_node_from_pin(link.source_pin_id);
+            if (source_node_id != -1) {
+                const DSPNode* n = engine_.graph().find_node(source_node_id);
+                if (n && n->routing_type == NodeRoutingType::Splitter) {
+                    if (n->output_pin_ids.size() > 2) {
+                        int idx = -1;
+                        for (size_t i = 0; i < n->output_pin_ids.size(); ++i) {
+                            if (n->output_pin_ids[i] == link.source_pin_id) {
+                                idx = i; break;
+                            }
+                        }
+                        if (engine_.graph().remove_output_pin(source_node_id, link.source_pin_id)) {
+                            auto_removed_out_pins.push_back({source_node_id, link.source_pin_id, idx, 1.0f});
                         }
                     }
                 }
@@ -120,6 +139,9 @@ struct RemoveGraphNodeCommand : public Command {
         
         for (auto it = auto_removed_pins.rbegin(); it != auto_removed_pins.rend(); ++it) {
             engine_.graph().restore_input_pin(it->node_id, it->pin_id, it->index, it->gain);
+        }
+        for (auto it = auto_removed_out_pins.rbegin(); it != auto_removed_out_pins.rend(); ++it) {
+            engine_.graph().restore_output_pin(it->node_id, it->pin_id, it->index);
         }
         for (const auto& link : severed_links) {
             engine_.graph().restore_link(link);
@@ -139,6 +161,10 @@ struct AddGraphLinkCommand : public Command {
     int auto_added_pin_id = -1;
     int auto_added_pin_index = -1;
     float auto_added_pin_gain = 1.0f;
+    
+    int auto_added_out_pin_node_id = -1;
+    int auto_added_out_pin_id = -1;
+    int auto_added_out_pin_index = -1;
 
     AddGraphLinkCommand(AudioEngine& engine, int src_pin, int dst_pin)
         : engine_(engine) {
@@ -187,10 +213,38 @@ struct AddGraphLinkCommand : public Command {
                         }
                     }
                 }
+
+                int source_node_id = engine_.graph().get_node_from_pin(link.source_pin_id);
+                if (source_node_id != -1) {
+                    const DSPNode* node = engine_.graph().find_node(source_node_id);
+                    if (node && node->routing_type == NodeRoutingType::Splitter) {
+                        int occupied_count = 0;
+                        for (int p : node->output_pin_ids) {
+                            for (const auto& l : engine_.graph().get_links()) {
+                                if (l.source_pin_id == p) {
+                                    occupied_count++; break;
+                                }
+                            }
+                        }
+                        if (occupied_count == node->output_pin_ids.size()) {
+                            if (engine_.graph().add_output_pin(source_node_id)) {
+                                const DSPNode* updated_node = engine_.graph().find_node(source_node_id);
+                                int new_pin = updated_node->output_pin_ids.back();
+                                
+                                auto_added_out_pin_node_id = source_node_id;
+                                auto_added_out_pin_id = new_pin;
+                                auto_added_out_pin_index = updated_node->output_pin_ids.size() - 1;
+                            }
+                        }
+                    }
+                }
             }
         } else if (was_successful) {
             if (auto_added_pin_node_id != -1) {
                 engine_.graph().restore_input_pin(auto_added_pin_node_id, auto_added_pin_id, auto_added_pin_index, auto_added_pin_gain);
+            }
+            if (auto_added_out_pin_node_id != -1) {
+                engine_.graph().restore_output_pin(auto_added_out_pin_node_id, auto_added_out_pin_id, auto_added_out_pin_index);
             }
             engine_.graph().restore_link(link);
         }
@@ -205,6 +259,9 @@ struct AddGraphLinkCommand : public Command {
             engine_.graph().remove_link(link.id);
             if (auto_added_pin_node_id != -1) {
                 engine_.graph().remove_input_pin(auto_added_pin_node_id, auto_added_pin_id);
+            }
+            if (auto_added_out_pin_node_id != -1) {
+                engine_.graph().remove_output_pin(auto_added_out_pin_node_id, auto_added_out_pin_id);
             }
             engine_.commit_graph_changes();
         }
@@ -221,6 +278,10 @@ struct RemoveGraphLinkCommand : public Command {
     int auto_removed_pin_id = -1;
     int auto_removed_pin_index = -1;
     float auto_removed_pin_gain = 1.0f;
+    
+    int auto_removed_out_pin_node_id = -1;
+    int auto_removed_out_pin_id = -1;
+    int auto_removed_out_pin_index = -1;
 
     RemoveGraphLinkCommand(AudioEngine& engine, const GraphLink& l)
         : engine_(engine), link(l) {}
@@ -236,13 +297,32 @@ struct RemoveGraphLinkCommand : public Command {
                         for (size_t i = 0; i < node->input_pin_ids.size(); ++i) {
                             if (node->input_pin_ids[i] == link.dest_pin_id) {
                                 auto_removed_pin_index = i;
-                                auto_removed_pin_gain = node->input_gains[i];
+                                auto_removed_pin_gain = (i < node->input_gains.size()) ? node->input_gains[i] : 1.0f;
                                 break;
                             }
                         }
                         if (engine_.graph().remove_input_pin(dest_node_id, link.dest_pin_id)) {
                             auto_removed_pin_node_id = dest_node_id;
                             auto_removed_pin_id = link.dest_pin_id;
+                        }
+                    }
+                }
+            }
+
+            int source_node_id = engine_.graph().get_node_from_pin(link.source_pin_id);
+            if (source_node_id != -1) {
+                const DSPNode* node = engine_.graph().find_node(source_node_id);
+                if (node && node->routing_type == NodeRoutingType::Splitter) {
+                    if (node->output_pin_ids.size() > 2) {
+                        for (size_t i = 0; i < node->output_pin_ids.size(); ++i) {
+                            if (node->output_pin_ids[i] == link.source_pin_id) {
+                                auto_removed_out_pin_index = i;
+                                break;
+                            }
+                        }
+                        if (engine_.graph().remove_output_pin(source_node_id, link.source_pin_id)) {
+                            auto_removed_out_pin_node_id = source_node_id;
+                            auto_removed_out_pin_id = link.source_pin_id;
                         }
                     }
                 }
@@ -255,6 +335,9 @@ struct RemoveGraphLinkCommand : public Command {
     void undo() override {
         if (auto_removed_pin_node_id != -1) {
             engine_.graph().restore_input_pin(auto_removed_pin_node_id, auto_removed_pin_id, auto_removed_pin_index, auto_removed_pin_gain);
+        }
+        if (auto_removed_out_pin_node_id != -1) {
+            engine_.graph().restore_output_pin(auto_removed_out_pin_node_id, auto_removed_out_pin_id, auto_removed_out_pin_index);
         }
         engine_.graph().restore_link(link);
         engine_.commit_graph_changes();

--- a/src/gui/pedalboard/pedal_board_chain.cpp
+++ b/src/gui/pedalboard/pedal_board_chain.cpp
@@ -61,6 +61,8 @@ void PedalBoard::render_signal_chain() {
   }
 
   ImGui::SetNextItemAllowOverlap();
+  if (canvas_size.x <= 0.0f) canvas_size.x = 1.0f;
+  if (canvas_size.y <= 0.0f) canvas_size.y = 1.0f;
   ImGui::InvisibleButton("canvas_panning_hotspot", canvas_size, btn_flags);
   // Update canvas_hovered here — after InvisibleButton — so it reflects the
   // actual canvas item

--- a/src/gui/pedalboard/pedal_board_chain.cpp
+++ b/src/gui/pedalboard/pedal_board_chain.cpp
@@ -1,491 +1,707 @@
+#include "gui/commands/command.h"
 #include "gui/pedalboard/pedal_board.h"
 #include "gui/pedalboard/pedal_widget.h"
-#include "gui/theme/theme.h"
 #include "gui/state/gui_graph_state.h"
-#include "gui/commands/command.h"
+#include "gui/theme/theme.h"
+#include "gui/views/gui_midi.h"
+#include <cmath>
 #include <imgui.h>
 #include <unordered_map>
-#include <cmath>
 namespace Amplitron {
 void PedalBoard::render_signal_chain() {
-    auto& ui_state = GuiGraphState::get_instance();
-    // canvas_hovered is updated after the InvisibleButton is drawn (see below)
-    float dt = ImGui::GetIO().DeltaTime;
-    float lerp_factor = 1.0f - std::exp(-30.0f * dt);
-    if (lerp_factor < 0.0f) lerp_factor = 0.0f;
-    if (lerp_factor > 1.0f) lerp_factor = 1.0f;
-    float old_zoom = ui_state.zoom;
-    if (std::abs(ui_state.target_zoom - ui_state.zoom) > 0.0001f) {
-        ui_state.zoom += (ui_state.target_zoom - ui_state.zoom) * lerp_factor;
-    } else {
-        ui_state.zoom = ui_state.target_zoom;
-    }
-    if (old_zoom != ui_state.zoom) {
-        // Use canvas-local mouse coords to avoid drift when canvas is not at screen origin
-        float actual_factor = ui_state.zoom / old_zoom;
+  auto &ui_state = GuiGraphState::get_instance();
+  // canvas_hovered is updated after the InvisibleButton is drawn (see below)
+  float dt = ImGui::GetIO().DeltaTime;
+  float lerp_factor = 1.0f - std::exp(-30.0f * dt);
+  if (lerp_factor < 0.0f)
+    lerp_factor = 0.0f;
+  if (lerp_factor > 1.0f)
+    lerp_factor = 1.0f;
+  float old_zoom = ui_state.zoom;
+  if (std::abs(ui_state.target_zoom - ui_state.zoom) > 0.0001f) {
+    ui_state.zoom += (ui_state.target_zoom - ui_state.zoom) * lerp_factor;
+  } else {
+    ui_state.zoom = ui_state.target_zoom;
+  }
+  if (old_zoom != ui_state.zoom) {
+    // Use canvas-local mouse coords to avoid drift when canvas is not at screen
+    // origin
+    float actual_factor = ui_state.zoom / old_zoom;
+    ImVec2 mouse_pos = ImGui::GetMousePos();
+    ImVec2 canvas_pos_now = ui_state.last_canvas_pos;
+    float local_x = mouse_pos.x - canvas_pos_now.x;
+    float local_y = mouse_pos.y - canvas_pos_now.y;
+    ui_state.scrolling.x =
+        local_x - (local_x - ui_state.scrolling.x) * actual_factor;
+    ui_state.scrolling.y =
+        local_y - (local_y - ui_state.scrolling.y) * actual_factor;
+    ui_state.target_scrolling = ui_state.scrolling;
+  }
+  if (std::abs(ui_state.target_scrolling.x - ui_state.scrolling.x) > 0.01f ||
+      std::abs(ui_state.target_scrolling.y - ui_state.scrolling.y) > 0.01f) {
+    ui_state.scrolling.x +=
+        (ui_state.target_scrolling.x - ui_state.scrolling.x) * lerp_factor;
+    ui_state.scrolling.y +=
+        (ui_state.target_scrolling.y - ui_state.scrolling.y) * lerp_factor;
+  } else {
+    ui_state.scrolling = ui_state.target_scrolling;
+  }
+  auto &audio_graph = engine_.graph();
+  ImDrawList *draw_list = ImGui::GetWindowDrawList();
+  ImVec2 canvas_pos = ImGui::GetCursorScreenPos();
+  ImVec2 canvas_size = ImGui::GetContentRegionAvail();
+  ImVec2 canvas_end =
+      ImVec2(canvas_pos.x + canvas_size.x, canvas_pos.y + canvas_size.y);
+  ui_state.last_canvas_pos = canvas_pos;
+  ImGui::SetCursorScreenPos(canvas_pos);
+  ImGuiButtonFlags btn_flags =
+      ImGuiButtonFlags_MouseButtonRight | ImGuiButtonFlags_MouseButtonMiddle;
+  if (ui_state.hand_tool_active) {
+    btn_flags |= ImGuiButtonFlags_MouseButtonLeft;
+  }
+
+  ImGui::SetNextItemAllowOverlap();
+  ImGui::InvisibleButton("canvas_panning_hotspot", canvas_size, btn_flags);
+  // Update canvas_hovered here — after InvisibleButton — so it reflects the
+  // actual canvas item
+  ui_state.canvas_hovered = ImGui::IsItemHovered();
+
+  if (ui_state.hand_tool_active && ImGui::IsItemHovered()) {
+    ImGui::SetMouseCursor(ImGuiMouseCursor_Hand);
+  }
+
+  if (ImGui::IsItemActive() &&
+      (ImGui::IsMouseDragging(ImGuiMouseButton_Right) ||
+       ImGui::IsMouseDragging(ImGuiMouseButton_Middle) ||
+       (ui_state.hand_tool_active &&
+        ImGui::IsMouseDragging(ImGuiMouseButton_Left)))) {
+    ui_state.scrolling.x +=
+        ImGui::GetIO().MousePos.x - ImGui::GetIO().MousePosPrev.x;
+    ui_state.scrolling.y +=
+        ImGui::GetIO().MousePos.y - ImGui::GetIO().MousePosPrev.y;
+    ui_state.target_scrolling = ui_state.scrolling;
+  }
+  // Zooming is now allowed in both fullscreen and normal modes
+  if (ImGui::IsItemHovered()) {
+    float scroll_x = ImGui::GetIO().MouseWheelH;
+    float scroll_y = ImGui::GetIO().MouseWheel;
+    if (scroll_x != 0.0f || scroll_y != 0.0f) {
+      if (ImGui::GetIO().KeyCtrl) {
+        float zoom_factor = std::pow(1.1f, scroll_y);
         ImVec2 mouse_pos = ImGui::GetMousePos();
-        ImVec2 canvas_pos_now = ui_state.last_canvas_pos;
-        float local_x = mouse_pos.x - canvas_pos_now.x;
-        float local_y = mouse_pos.y - canvas_pos_now.y;
-        ui_state.scrolling.x = local_x - (local_x - ui_state.scrolling.x) * actual_factor;
-        ui_state.scrolling.y = local_y - (local_y - ui_state.scrolling.y) * actual_factor;
-        ui_state.target_scrolling = ui_state.scrolling;
+        ImVec2 mouse_in_canvas =
+            ImVec2(mouse_pos.x - canvas_pos.x, mouse_pos.y - canvas_pos.y);
+        float old_zoom = ui_state.target_zoom;
+        float new_zoom = old_zoom * zoom_factor;
+        if (new_zoom < 0.2f)
+          new_zoom = 0.2f;
+        if (new_zoom > 5.0f)
+          new_zoom = 5.0f;
+        float actual_factor = new_zoom / old_zoom;
+        ui_state.target_scrolling.x =
+            mouse_in_canvas.x -
+            (mouse_in_canvas.x - ui_state.target_scrolling.x) * actual_factor;
+        ui_state.target_scrolling.y =
+            mouse_in_canvas.y -
+            (mouse_in_canvas.y - ui_state.target_scrolling.y) * actual_factor;
+        ui_state.target_zoom = new_zoom;
+      } else {
+        ui_state.target_scrolling.x += scroll_x * 20.0f;
+        ui_state.target_scrolling.y += scroll_y * 20.0f;
+      }
     }
-    if (std::abs(ui_state.target_scrolling.x - ui_state.scrolling.x) > 0.01f ||
-        std::abs(ui_state.target_scrolling.y - ui_state.scrolling.y) > 0.01f) {
-        ui_state.scrolling.x += (ui_state.target_scrolling.x - ui_state.scrolling.x) * lerp_factor;
-        ui_state.scrolling.y += (ui_state.target_scrolling.y - ui_state.scrolling.y) * lerp_factor;
+  }
+  // Draw fullscreen button at top right
+  ImGui::SetCursorScreenPos(
+      ImVec2(canvas_pos.x + canvas_size.x - 70, canvas_pos.y + 10));
+  ImGui::SetNextItemAllowOverlap();
+  if (ImGui::Button(ui_state.is_fullscreen ? "Exit FS" : "Full Screen")) {
+    ui_state.is_fullscreen = !ui_state.is_fullscreen;
+    if (!ui_state.is_fullscreen) {
+      ui_state.zoom = 1.0f;
+      ui_state.target_zoom = 1.0f;
+    }
+  }
+  if (ui_state.show_grid) {
+    float GRID_SZ = 32.0f * ui_state.zoom;
+    ImU32 GRID_COLOR = IM_COL32(36, 34, 30, 255);
+    for (float x = std::fmod(ui_state.scrolling.x, GRID_SZ); x < canvas_size.x;
+         x += GRID_SZ) {
+      draw_list->AddLine(ImVec2(canvas_pos.x + x, canvas_pos.y),
+                         ImVec2(canvas_pos.x + x, canvas_end.y), GRID_COLOR);
+    }
+    for (float y = std::fmod(ui_state.scrolling.y, GRID_SZ); y < canvas_size.y;
+         y += GRID_SZ) {
+      draw_list->AddLine(ImVec2(canvas_pos.x, canvas_pos.y + y),
+                         ImVec2(canvas_end.x, canvas_pos.y + y), GRID_COLOR);
+    }
+  }
+  draw_list->PushClipRect(canvas_pos, canvas_end, true);
+  ImVec2 offset = ImVec2(canvas_pos.x + ui_state.scrolling.x,
+                         canvas_pos.y + ui_state.scrolling.y);
+  std::unordered_map<int, ImVec2> pin_positions_cache;
+  int node_to_delete = -1; // Safely track deletions outside the render loop
+  // Prune stale nodes from the UI state if the backend graph was reset or
+  // rebuilt
+  std::vector<int> stale_ids;
+  for (auto &pair : ui_state.node_positions) {
+    if (!audio_graph.find_node(pair.first)) {
+      stale_ids.push_back(pair.first);
+    }
+  }
+  for (int id : stale_ids) {
+    ui_state.node_positions.erase(id);
+  }
+  // Give all new nodes a default position at the end of the chain without
+  // shifting existing nodes
+  for (const auto &node : audio_graph.get_nodes()) {
+    if (ui_state.node_positions.find(node.id) ==
+        ui_state.node_positions.end()) {
+      if (node.x != 0.0f || node.y != 0.0f) {
+        ui_state.node_positions[node.id] = {ImVec2(node.x, node.y), false};
+      } else {
+        float max_right = 40.0f;
+        for (const auto &existing_node : audio_graph.get_nodes()) {
+          auto pos_it = ui_state.node_positions.find(existing_node.id);
+          if (pos_it != ui_state.node_positions.end()) {
+            float width =
+                (existing_node.routing_type == NodeRoutingType::StandardEffect)
+                    ? 190.0f
+                    : 110.0f;
+            float right_edge = pos_it->second.position.x + width;
+            if (right_edge > max_right) {
+              max_right = right_edge;
+            }
+          }
+        }
+        float insert_x =
+            ui_state.node_positions.empty() ? 40.0f : max_right + 80.0f;
+        ui_state.node_positions[node.id] = {ImVec2(insert_x, 60.0f), false};
+      }
+    }
+  }
+  // Animation pulse based on time and audio level
+  float level = engine_.get_output_level();
+  float time = (float)ImGui::GetTime();
+  bool is_running = engine_.is_running();
+  for (const auto &node : audio_graph.get_nodes()) {
+    auto &node_layout = ui_state.node_positions[node.id];
+    ImVec2 node_screen_pos =
+        ImVec2(offset.x + node_layout.position.x * ui_state.zoom,
+               offset.y + node_layout.position.y * ui_state.zoom);
+    PedalWidget *target_widget = nullptr;
+    if (node.routing_type == NodeRoutingType::StandardEffect) {
+      for (auto &w : widgets_) {
+        if (w->get_effect() == node.pedal) {
+          target_widget = w.get();
+          break;
+        }
+      }
+    }
+    bool is_mb_comp = false;
+    if (target_widget && std::strcmp(target_widget->get_effect()->name(),
+                                     "MultiBand Compressor") == 0) {
+      is_mb_comp = true;
+    }
+    float node_width =
+        (target_widget ? (is_mb_comp ? 190.0f * 2.2f : 190.0f) : 110.0f) *
+        ui_state.zoom;
+    float node_height = (target_widget ? 360.0f : 70.0f) * ui_state.zoom;
+    if (!target_widget && (node.routing_type == NodeRoutingType::Mixer ||
+                           node.routing_type == NodeRoutingType::MergeSum)) {
+      node_width = 130.0f * ui_state.zoom;
+      node_height =
+          std::max(70.0f, (float)node.input_pin_ids.size() * 32.0f + 55.0f) *
+          ui_state.zoom;
+    }
+    ImGui::PushID(node.id);
+    if (target_widget) {
+      ImGui::SetCursorScreenPos(node_screen_pos);
+      ImGui::BeginGroup();
+      ImGui::SetWindowFontScale(ui_state.zoom);
+      target_widget->render(ui_state.zoom);
+      ImGui::SetWindowFontScale(1.0f);
+      ImGui::EndGroup();
+      ImGui::SetCursorScreenPos(node_screen_pos);
+      ImGui::SetNextItemAllowOverlap();
+      ImGui::InvisibleButton(
+          "native_drag_handle",
+          ImVec2(node_width - 25.0f * ui_state.zoom, 30.0f * ui_state.zoom));
+      if (!ui_state.hand_tool_active && ImGui::IsItemActive() &&
+          ImGui::IsMouseDragging(ImGuiMouseButton_Left)) {
+        if (!node_layout.is_dragging) {
+          node_layout.is_dragging = true;
+          node_layout.drag_start_pos = node_layout.position;
+        }
+        node_layout.position.x += ImGui::GetIO().MouseDelta.x / ui_state.zoom;
+        node_layout.position.y += ImGui::GetIO().MouseDelta.y / ui_state.zoom;
+      } else if (node_layout.is_dragging && ImGui::IsItemDeactivated()) {
+        node_layout.is_dragging = false;
+        if (node_layout.position.x != node_layout.drag_start_pos.x ||
+            node_layout.position.y != node_layout.drag_start_pos.y) {
+          history_.push_executed(std::make_unique<MoveGraphNodeCommand>(
+              node.id, node_layout.drag_start_pos, node_layout.position));
+        }
+      }
     } else {
-        ui_state.scrolling = ui_state.target_scrolling;
-    }
-    auto& audio_graph = engine_.graph(); 
-    ImDrawList* draw_list = ImGui::GetWindowDrawList();
-    ImVec2 canvas_pos = ImGui::GetCursorScreenPos();
-    ImVec2 canvas_size = ImGui::GetContentRegionAvail();
-    ImVec2 canvas_end = ImVec2(canvas_pos.x + canvas_size.x, canvas_pos.y + canvas_size.y);
-    ui_state.last_canvas_pos = canvas_pos;
-    ImGui::SetCursorScreenPos(canvas_pos);
-    ImGuiButtonFlags btn_flags = ImGuiButtonFlags_MouseButtonRight | ImGuiButtonFlags_MouseButtonMiddle;
-    if (ui_state.hand_tool_active) {
-        btn_flags |= ImGuiButtonFlags_MouseButtonLeft;
-    }
-    
-    ImGui::SetNextItemAllowOverlap();
-    ImGui::InvisibleButton("canvas_panning_hotspot", canvas_size, btn_flags);
-    // Update canvas_hovered here — after InvisibleButton — so it reflects the actual canvas item
-    ui_state.canvas_hovered = ImGui::IsItemHovered();
-    
-    if (ui_state.hand_tool_active && ImGui::IsItemHovered()) {
-        ImGui::SetMouseCursor(ImGuiMouseCursor_Hand);
-    }
-    
-    if (ImGui::IsItemActive() && (ImGui::IsMouseDragging(ImGuiMouseButton_Right) || 
-                                  ImGui::IsMouseDragging(ImGuiMouseButton_Middle) || 
-                                  (ui_state.hand_tool_active && ImGui::IsMouseDragging(ImGuiMouseButton_Left)))) {
-        ui_state.scrolling.x += ImGui::GetIO().MousePos.x - ImGui::GetIO().MousePosPrev.x;
-        ui_state.scrolling.y += ImGui::GetIO().MousePos.y - ImGui::GetIO().MousePosPrev.y;
-        ui_state.target_scrolling = ui_state.scrolling;
-    }
-    // Zooming is now allowed in both fullscreen and normal modes
-    if (ImGui::IsItemHovered()) {
-        float scroll_x = ImGui::GetIO().MouseWheelH;
-        float scroll_y = ImGui::GetIO().MouseWheel;
-        if (scroll_x != 0.0f || scroll_y != 0.0f) {
-            if (ImGui::GetIO().KeyCtrl) {
-                float zoom_factor = std::pow(1.1f, scroll_y);
-                ImVec2 mouse_pos = ImGui::GetMousePos();
-                ImVec2 mouse_in_canvas = ImVec2(mouse_pos.x - canvas_pos.x, mouse_pos.y - canvas_pos.y);
-                float old_zoom = ui_state.target_zoom;
-                float new_zoom = old_zoom * zoom_factor;
-                if (new_zoom < 0.2f) new_zoom = 0.2f;
-                if (new_zoom > 5.0f) new_zoom = 5.0f;
-                float actual_factor = new_zoom / old_zoom;
-                ui_state.target_scrolling.x = mouse_in_canvas.x - (mouse_in_canvas.x - ui_state.target_scrolling.x) * actual_factor;
-                ui_state.target_scrolling.y = mouse_in_canvas.y - (mouse_in_canvas.y - ui_state.target_scrolling.y) * actual_factor;
-                ui_state.target_zoom = new_zoom;
+      ImVec2 node_end = ImVec2(node_screen_pos.x + node_width,
+                               node_screen_pos.y + node_height);
+      ImU32 bg_color = IM_COL32(50, 35, 60, 255);
+      draw_list->AddRectFilled(node_screen_pos, node_end, bg_color,
+                               Theme::ROUNDING_MD * ui_state.zoom);
+      draw_list->AddRect(node_screen_pos, node_end, IM_COL32(180, 140, 80, 180),
+                         Theme::ROUNDING_MD * ui_state.zoom, 0,
+                         1.5f * ui_state.zoom);
+      ImGui::SetCursorScreenPos(node_screen_pos);
+      ImGui::SetNextItemAllowOverlap();
+      ImGui::InvisibleButton(
+          "util_drag_handle",
+          ImVec2(node_width - 25.0f * ui_state.zoom, node_height));
+      if (!ui_state.hand_tool_active && ImGui::IsItemActive() &&
+          ImGui::IsMouseDragging(ImGuiMouseButton_Left)) {
+        if (!node_layout.is_dragging) {
+          node_layout.is_dragging = true;
+          node_layout.drag_start_pos = node_layout.position;
+        }
+        node_layout.position.x += ImGui::GetIO().MouseDelta.x / ui_state.zoom;
+        node_layout.position.y += ImGui::GetIO().MouseDelta.y / ui_state.zoom;
+      } else if (node_layout.is_dragging && ImGui::IsItemDeactivated()) {
+        node_layout.is_dragging = false;
+        if (node_layout.position.x != node_layout.drag_start_pos.x ||
+            node_layout.position.y != node_layout.drag_start_pos.y) {
+          history_.push_executed(std::make_unique<MoveGraphNodeCommand>(
+              node.id, node_layout.drag_start_pos, node_layout.position));
+        }
+      }
+
+      bool is_mixer = (node.routing_type == NodeRoutingType::Mixer ||
+                       node.routing_type == NodeRoutingType::MergeSum);
+
+      if (is_mixer && ImGui::IsItemHovered() &&
+          ImGui::IsMouseClicked(ImGuiMouseButton_Right)) {
+        ImGui::OpenPopup("MixerContextMenu");
+      }
+      if (ImGui::BeginPopup("MixerContextMenu")) {
+        if (ImGui::MenuItem("Add Input", nullptr, false,
+                            node.input_pin_ids.size() < 8)) {
+          audio_graph.add_input_pin(node.id);
+          engine_.commit_graph_changes();
+        }
+        if (ImGui::MenuItem("Remove Last Input", nullptr, false,
+                            node.input_pin_ids.size() > 2)) {
+          if (audio_graph.remove_input_pin(node.id)) {
+            engine_.commit_graph_changes();
+          }
+        }
+        ImGui::EndPopup();
+      }
+
+      std::string display_name = node.name;
+      if (is_mixer) {
+        display_name = std::to_string(node.input_pin_ids.size()) + "-in Mixer";
+      }
+      ImVec2 text_pos = ImVec2(node_screen_pos.x + 12.0f * ui_state.zoom,
+                               node_screen_pos.y + 10.0f * ui_state.zoom);
+      ImGui::SetWindowFontScale(ui_state.zoom);
+      draw_list->AddText(text_pos, IM_COL32(255, 255, 255, 255),
+                         display_name.c_str());
+      ImGui::SetWindowFontScale(1.0f);
+
+      if (is_mixer) {
+        ImGui::SetWindowFontScale(ui_state.zoom * 0.8f);
+        for (size_t idx = 0; idx < node.input_pin_ids.size(); ++idx) {
+          float pin_y =
+              node_screen_pos.y +
+              (node_height * (idx + 1.0f) / (node.input_pin_ids.size() + 1.0f));
+          ImGui::SetCursorScreenPos(
+              ImVec2(node_screen_pos.x + 8.0f * ui_state.zoom,
+                     pin_y - 8.0f * ui_state.zoom));
+          ImGui::PushID(static_cast<int>(idx));
+          
+          ImGui::Text("In %d", (int)(idx + 1));
+          ImGui::SameLine();
+          ImGui::PushItemWidth(65.0f * ui_state.zoom);
+
+          float gain = 1.0f;
+          if (idx < node.input_gains.size())
+            gain = node.input_gains[idx];
+
+          if (ImGui::SliderFloat("##gain", &gain, 0.0f, 2.0f, "%.2f")) {
+            audio_graph.set_mixer_input_gain(node.id, idx, gain);
+            engine_.push_mixer_gain_change(node.id, idx, gain);
+          }
+
+          if (ImGui::IsItemHovered() &&
+              ImGui::IsMouseClicked(ImGuiMouseButton_Right)) {
+            ImGui::OpenPopup("GainMidiMenu");
+          }
+
+          if (ImGui::BeginPopup("GainMidiMenu")) {
+            std::string effect_name = "Mixer_" + std::to_string(node.id);
+            std::string param_name = "Gain " + std::to_string(idx);
+            if (gui_midi_) {
+              if (gui_midi_->render_remove_mapping_item(effect_name,
+                                                        param_name)) {
+              }
+              if (gui_midi_->render_learn_menu_item(effect_name, param_name)) {
+              }
             } else {
-                ui_state.target_scrolling.x += scroll_x * 20.0f;
-                ui_state.target_scrolling.y += scroll_y * 20.0f;
+              ImGui::TextDisabled("MIDI manager not available");
             }
+            ImGui::EndPopup();
+          }
+
+          ImGui::PopItemWidth();
+          ImGui::PopID();
         }
+        
+        ImGui::SetWindowFontScale(ui_state.zoom * 0.7f);
+        ImGui::SetCursorScreenPos(
+            ImVec2(node_screen_pos.x + 35.0f * ui_state.zoom,
+                   node_screen_pos.y + node_height - 16.0f * ui_state.zoom));
+        ImGui::TextDisabled("(Gain Fader)");
+        ImGui::SetWindowFontScale(1.0f);
+      }
     }
-    // Draw fullscreen button at top right
-    ImGui::SetCursorScreenPos(ImVec2(canvas_pos.x + canvas_size.x - 70, canvas_pos.y + 10));
-    ImGui::SetNextItemAllowOverlap();
-    if (ImGui::Button(ui_state.is_fullscreen ? "Exit FS" : "Full Screen")) {
-        ui_state.is_fullscreen = !ui_state.is_fullscreen;
-        if (!ui_state.is_fullscreen) {
-            ui_state.zoom = 1.0f;
-            ui_state.target_zoom = 1.0f;
-        }
+    if (!node.is_reachable) {
+      ImVec2 node_end = ImVec2(node_screen_pos.x + node_width,
+                               node_screen_pos.y + node_height);
+      draw_list->AddRectFilled(node_screen_pos, node_end,
+                               IM_COL32(0, 0, 0, 180),
+                               Theme::ROUNDING_MD * ui_state.zoom);
+
+      ImVec2 text_pos =
+          ImVec2(node_screen_pos.x + 10.0f * ui_state.zoom,
+                 node_screen_pos.y + node_height - 25.0f * ui_state.zoom);
+      ImGui::SetWindowFontScale(ui_state.zoom * 0.9f);
+      draw_list->AddText(text_pos, IM_COL32(255, 60, 60, 255), "DISCONNECTED");
+      ImGui::SetWindowFontScale(1.0f);
     }
-    if (ui_state.show_grid) {
-        float GRID_SZ = 32.0f * ui_state.zoom;
-        ImU32 GRID_COLOR = IM_COL32(36, 34, 30, 255);
-        for (float x = std::fmod(ui_state.scrolling.x, GRID_SZ); x < canvas_size.x; x += GRID_SZ) {
-            draw_list->AddLine(ImVec2(canvas_pos.x + x, canvas_pos.y), ImVec2(canvas_pos.x + x, canvas_end.y), GRID_COLOR);
+    // --- INTERNAL SIGNAL FLOW / ELECTRICITY EFFECT ---
+    if (node.is_reachable &&
+        (!node.input_pin_ids.empty() || !node.output_pin_ids.empty())) {
+      bool enabled = true;
+      if (target_widget) {
+        enabled = target_widget->get_effect()->is_enabled();
+      }
+      // Align with pins
+      float in_y = node_screen_pos.y + node_height * 0.5f;
+      if (!node.input_pin_ids.empty()) {
+        in_y = node_screen_pos.y +
+               (node_height * (0 + 1.0f) / (node.input_pin_ids.size() + 1.0f));
+      }
+      float out_y = node_screen_pos.y + node_height * 0.5f;
+      if (!node.output_pin_ids.empty()) {
+        out_y = node_screen_pos.y + (node_height * (0 + 1.0f) /
+                                     (node.output_pin_ids.size() + 1.0f));
+      }
+
+      ImVec2 flow_p1(node_screen_pos.x, in_y);
+      ImVec2 flow_p2(node_screen_pos.x + node_width, out_y);
+      // --- COLOR & PULSE CALCULATIONS (SHARED) ---
+      ImU32 flow_col = IM_COL32(200, 230, 255, 255);
+      if (target_widget) {
+        const auto *colors =
+            get_effect_color(target_widget->get_effect()->name());
+        flow_col = ImGui::ColorConvertFloat4ToU32(colors->led_color);
+      }
+
+      ImU32 r = (flow_col >> 0) & 0xFF;
+      ImU32 g = (flow_col >> 8) & 0xFF;
+      ImU32 b = (flow_col >> 16) & 0xFF;
+      float pulse = 0.6f + 0.4f * std::sin(time * 8.0f) * (0.5f + level * 2.0f);
+      float jitter = std::sin(time * 40.0f) * 1.5f * ui_state.zoom;
+      if (enabled) {
+        // --- ELECTRICITY PASSING THROUGH (ACTIVE) ---
+        // No internal line, only glowing edges
+        ImVec2 p_min(node_screen_pos.x - (2.0f + jitter),
+                     node_screen_pos.y - (2.0f + jitter));
+        ImVec2 p_max(node_screen_pos.x + node_width + (2.0f + jitter),
+                     node_screen_pos.y + node_height + (2.0f + jitter));
+
+        draw_list->AddRect(p_min, p_max, IM_COL32(r, g, b, (int)(180 * pulse)),
+                           Theme::ROUNDING_MD * ui_state.zoom, 0,
+                           3.0f * ui_state.zoom);
+        draw_list->AddRect(
+            p_min, p_max, IM_COL32(255, 255, 255, (int)(220 * pulse)),
+            Theme::ROUNDING_MD * ui_state.zoom, 0, 1.0f * ui_state.zoom);
+      } else {
+        // --- ELECTRIC HIGH-RAIL BYPASS PATH ---
+        // Rectangular "bridge" with CONSISTENT glow style
+        float rail_height = 65.0f * ui_state.zoom;
+        float rail_y = node_screen_pos.y - rail_height;
+
+        ImVec2 p_rail_in(flow_p1.x, rail_y);
+        ImVec2 p_rail_out(flow_p2.x, rail_y);
+        auto draw_consistent_glow_line = [&](ImVec2 p1, ImVec2 p2) {
+          ImVec2 p1j(p1.x, p1.y + jitter);
+          ImVec2 p2j(p2.x, p2.y + jitter);
+          draw_list->AddLine(p1j, p2j, IM_COL32(r, g, b, (int)(180 * pulse)),
+                             4.0f * ui_state.zoom);
+          draw_list->AddLine(p1j, p2j,
+                             IM_COL32(255, 255, 255, (int)(220 * pulse)),
+                             1.5f * ui_state.zoom);
+        };
+        // Bridge segments
+        draw_consistent_glow_line(flow_p1, p_rail_in);
+        draw_consistent_glow_line(p_rail_in, p_rail_out);
+        draw_consistent_glow_line(p_rail_out, flow_p2);
+        // --- MOVING ELECTRONS (PULSES) ---
+        // Electrons travel along the bridge path: Up -> Across -> Down
+        float electron_time = std::fmod(time * 2.5f, 1.0f);
+        for (int e = 0; e < 2; ++e) {
+          float t = std::fmod(electron_time + e * 0.5f, 1.0f);
+          ImVec2 electron_pos;
+
+          if (t < 0.2f) { // Segment 1: Up
+            float st = t / 0.2f;
+            electron_pos = ImVec2(
+                flow_p1.x, flow_p1.y + (rail_y - flow_p1.y) * st + jitter);
+          } else if (t < 0.8f) { // Segment 2: Across
+            float st = (t - 0.2f) / 0.6f;
+            electron_pos =
+                ImVec2(p_rail_in.x + (p_rail_out.x - p_rail_in.x) * st,
+                       rail_y + jitter);
+          } else { // Segment 3: Down
+            float st = (t - 0.8f) / 0.2f;
+            electron_pos = ImVec2(p_rail_out.x,
+                                  rail_y + (flow_p2.y - rail_y) * st + jitter);
+          }
+
+          draw_list->AddCircleFilled(
+              electron_pos, 3.5f * ui_state.zoom,
+              IM_COL32(255, 255, 255, (int)(220 * pulse)));
+          draw_list->AddCircle(electron_pos, 7.0f * ui_state.zoom,
+                               IM_COL32(r, g, b, (int)(180 * pulse)), 0,
+                               2.0f * ui_state.zoom);
         }
-        for (float y = std::fmod(ui_state.scrolling.y, GRID_SZ); y < canvas_size.y; y += GRID_SZ) {
-            draw_list->AddLine(ImVec2(canvas_pos.x, canvas_pos.y + y), ImVec2(canvas_end.x, canvas_pos.y + y), GRID_COLOR);
+        if (ImGui::IsMouseHoveringRect(ImVec2(node_screen_pos.x, rail_y - 10),
+                                       flow_p2)) {
+          ImGui::SetTooltip("%s (Bypassed - High Rail Signal Path)",
+                            target_widget->get_effect()->name());
         }
+      }
+      if (ImGui::IsMouseHoveringRect(flow_p1, flow_p2) &&
+          (target_widget || !node.name.empty())) {
+        const char *name = target_widget ? target_widget->get_effect()->name()
+                                         : node.name.c_str();
+        ImGui::SetTooltip("%s (%s)", name, enabled ? "Active" : "Bypassed");
+      }
     }
-    draw_list->PushClipRect(canvas_pos, canvas_end, true);
-    ImVec2 offset = ImVec2(canvas_pos.x + ui_state.scrolling.x, canvas_pos.y + ui_state.scrolling.y);
-    std::unordered_map<int, ImVec2> pin_positions_cache;
-    int node_to_delete = -1; // Safely track deletions outside the render loop
-    // Prune stale nodes from the UI state if the backend graph was reset or rebuilt
-    std::vector<int> stale_ids;
-    for (auto& pair : ui_state.node_positions) {
-        if (!audio_graph.find_node(pair.first)) {
-            stale_ids.push_back(pair.first);
-        }
+    // ====================================================================
+    // THE DELETION [X] BUTTON
+    // ====================================================================
+    bool is_amp = (node.name == "Amp Sim");
+    bool is_input_node = (node.name == "Input");
+    if (!is_amp && !is_input_node) {
+      ImVec2 cross_pos =
+          ImVec2(node_screen_pos.x + node_width - 24.0f * ui_state.zoom,
+                 node_screen_pos.y + 4.0f * ui_state.zoom);
+      ImGui::SetCursorScreenPos(cross_pos);
+
+      // Your exact color styling
+      ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.0f, 0.0f, 0.0f, 0.0f));
+      ImGui::PushStyleColor(ImGuiCol_ButtonHovered,
+                            ImVec4(0.6f, 0.1f, 0.1f, 0.8f));
+
+      // Use SmallButton and exact string formatting
+      std::string remove_label = "X##rm" + std::to_string(node.id);
+      ImGui::SetNextItemAllowOverlap();
+      if (ImGui::SmallButton(remove_label.c_str())) {
+        node_to_delete = node.id;
+      }
+      if (ImGui::IsItemHovered()) {
+        ImGui::SetTooltip("Remove %s from chain", node.name.c_str());
+      }
+
+      ImGui::PopStyleColor(2);
     }
-    for (int id : stale_ids) {
-        ui_state.node_positions.erase(id);
-    }
-    // Give all new nodes a default position at the end of the chain without shifting existing nodes
-    for (const auto& node : audio_graph.get_nodes()) {
-        if (ui_state.node_positions.find(node.id) == ui_state.node_positions.end()) {
-            if (node.x != 0.0f || node.y != 0.0f) {
-                ui_state.node_positions[node.id] = { ImVec2(node.x, node.y), false };
-            } else {
-                float max_right = 40.0f;
-                for (const auto& existing_node : audio_graph.get_nodes()) {
-                    auto pos_it = ui_state.node_positions.find(existing_node.id);
-                    if (pos_it != ui_state.node_positions.end()) {
-                        float width = (existing_node.routing_type == NodeRoutingType::StandardEffect) ? 190.0f : 110.0f;
-                        float right_edge = pos_it->second.position.x + width;
-                        if (right_edge > max_right) {
-                            max_right = right_edge;
-                        }
-                    }
-                }
-                float insert_x = ui_state.node_positions.empty() ? 40.0f : max_right + 80.0f;
-                ui_state.node_positions[node.id] = { ImVec2(insert_x, 60.0f), false };
-            }
-        }
-    }
-    // Animation pulse based on time and audio level
-    float level = engine_.get_output_level();
-    float time = (float)ImGui::GetTime();
-    bool is_running = engine_.is_running();
-    for (const auto& node : audio_graph.get_nodes()) {
-        auto& node_layout = ui_state.node_positions[node.id];
-        ImVec2 node_screen_pos = ImVec2(offset.x + node_layout.position.x * ui_state.zoom, offset.y + node_layout.position.y * ui_state.zoom);
-        PedalWidget* target_widget = nullptr;
-        if (node.routing_type == NodeRoutingType::StandardEffect) {
-            for (auto& w : widgets_) {
-                if (w->get_effect() == node.pedal) { target_widget = w.get(); break; }
-            }
-        }
-        bool is_mb_comp = false;
-        if (target_widget && std::strcmp(target_widget->get_effect()->name(), "MultiBand Compressor") == 0) {
-            is_mb_comp = true;
-        }
-        float node_width = (target_widget ? (is_mb_comp ? 190.0f * 2.2f : 190.0f) : 110.0f) * ui_state.zoom;
-        float node_height = (target_widget ? 360.0f : 70.0f) * ui_state.zoom;
-        ImGui::PushID(node.id);
-        if (target_widget) {
-            ImGui::SetCursorScreenPos(node_screen_pos);
-            ImGui::BeginGroup();
-            ImGui::SetWindowFontScale(ui_state.zoom);
-            target_widget->render(ui_state.zoom); 
-            ImGui::SetWindowFontScale(1.0f);
-            ImGui::EndGroup();
-            ImGui::SetCursorScreenPos(node_screen_pos);
-            ImGui::SetNextItemAllowOverlap(); 
-            ImGui::InvisibleButton("native_drag_handle", ImVec2(node_width - 25.0f * ui_state.zoom, 30.0f * ui_state.zoom));
-            if (!ui_state.hand_tool_active && ImGui::IsItemActive() && ImGui::IsMouseDragging(ImGuiMouseButton_Left)) {
-                if (!node_layout.is_dragging) {
-                    node_layout.is_dragging = true;
-                    node_layout.drag_start_pos = node_layout.position;
-                }
-                node_layout.position.x += ImGui::GetIO().MouseDelta.x / ui_state.zoom;
-                node_layout.position.y += ImGui::GetIO().MouseDelta.y / ui_state.zoom;
-            } else if (node_layout.is_dragging && ImGui::IsItemDeactivated()) {
-                node_layout.is_dragging = false;
-                if (node_layout.position.x != node_layout.drag_start_pos.x || node_layout.position.y != node_layout.drag_start_pos.y) {
-                    history_.push_executed(std::make_unique<MoveGraphNodeCommand>(node.id, node_layout.drag_start_pos, node_layout.position));
-                }
-            }
-        } else {
-            ImVec2 node_end = ImVec2(node_screen_pos.x + node_width, node_screen_pos.y + node_height);
-            ImU32 bg_color = IM_COL32(50, 35, 60, 255);
-            draw_list->AddRectFilled(node_screen_pos, node_end, bg_color, Theme::ROUNDING_MD * ui_state.zoom);
-            draw_list->AddRect(node_screen_pos, node_end, IM_COL32(180, 140, 80, 180), Theme::ROUNDING_MD * ui_state.zoom, 0, 1.5f * ui_state.zoom);
-            ImGui::SetCursorScreenPos(node_screen_pos);
-            ImGui::SetNextItemAllowOverlap();
-            ImGui::InvisibleButton("util_drag_handle", ImVec2(node_width - 25.0f * ui_state.zoom, node_height));
-            if (!ui_state.hand_tool_active && ImGui::IsItemActive() && ImGui::IsMouseDragging(ImGuiMouseButton_Left)) {
-                if (!node_layout.is_dragging) {
-                    node_layout.is_dragging = true;
-                    node_layout.drag_start_pos = node_layout.position;
-                }
-                node_layout.position.x += ImGui::GetIO().MouseDelta.x / ui_state.zoom;
-                node_layout.position.y += ImGui::GetIO().MouseDelta.y / ui_state.zoom;
-            } else if (node_layout.is_dragging && ImGui::IsItemDeactivated()) {
-                node_layout.is_dragging = false;
-                if (node_layout.position.x != node_layout.drag_start_pos.x || node_layout.position.y != node_layout.drag_start_pos.y) {
-                    history_.push_executed(std::make_unique<MoveGraphNodeCommand>(node.id, node_layout.drag_start_pos, node_layout.position));
-                }
-            }
-            ImVec2 text_pos = ImVec2(node_screen_pos.x + 12.0f * ui_state.zoom, node_screen_pos.y + 25.0f * ui_state.zoom);
-            ImGui::SetWindowFontScale(ui_state.zoom);
-            draw_list->AddText(text_pos, IM_COL32(255, 255, 255, 255), node.name.c_str());
-            ImGui::SetWindowFontScale(1.0f);
-        }
-        if (!node.is_reachable) {
-            ImVec2 node_end = ImVec2(node_screen_pos.x + node_width, node_screen_pos.y + node_height);
-            draw_list->AddRectFilled(node_screen_pos, node_end, IM_COL32(0, 0, 0, 180), Theme::ROUNDING_MD * ui_state.zoom);
-            
-            ImVec2 text_pos = ImVec2(node_screen_pos.x + 10.0f * ui_state.zoom, node_screen_pos.y + node_height - 25.0f * ui_state.zoom);
-            ImGui::SetWindowFontScale(ui_state.zoom * 0.9f);
-            draw_list->AddText(text_pos, IM_COL32(255, 60, 60, 255), "DISCONNECTED");
-            ImGui::SetWindowFontScale(1.0f);
-        }
-        // --- INTERNAL SIGNAL FLOW / ELECTRICITY EFFECT ---
-        if (node.is_reachable && (!node.input_pin_ids.empty() || !node.output_pin_ids.empty())) {
-            bool enabled = true;
-            if (target_widget) {
-                enabled = target_widget->get_effect()->is_enabled();
-            }
-            // Align with pins
-            float in_y = node_screen_pos.y + node_height * 0.5f;
-            if (!node.input_pin_ids.empty()) {
-                in_y = node_screen_pos.y + (node_height * (0 + 1.0f) / (node.input_pin_ids.size() + 1.0f));
-            }
-            float out_y = node_screen_pos.y + node_height * 0.5f;
-            if (!node.output_pin_ids.empty()) {
-                out_y = node_screen_pos.y + (node_height * (0 + 1.0f) / (node.output_pin_ids.size() + 1.0f));
-            }
-            
-            ImVec2 flow_p1(node_screen_pos.x, in_y);
-            ImVec2 flow_p2(node_screen_pos.x + node_width, out_y);
-            // --- COLOR & PULSE CALCULATIONS (SHARED) ---
-            ImU32 flow_col = IM_COL32(200, 230, 255, 255);
-            if (target_widget) {
-                const auto* colors = get_effect_color(target_widget->get_effect()->name());
-                flow_col = ImGui::ColorConvertFloat4ToU32(colors->led_color);
-            }
-            
-            ImU32 r = (flow_col >> 0) & 0xFF;
-            ImU32 g = (flow_col >> 8) & 0xFF;
-            ImU32 b = (flow_col >> 16) & 0xFF;
-            float pulse = 0.6f + 0.4f * std::sin(time * 8.0f) * (0.5f + level * 2.0f);
-            float jitter = std::sin(time * 40.0f) * 1.5f * ui_state.zoom;
-            if (enabled) {
-                // --- ELECTRICITY PASSING THROUGH (ACTIVE) ---
-                // No internal line, only glowing edges
-                ImVec2 p_min(node_screen_pos.x - (2.0f + jitter), node_screen_pos.y - (2.0f + jitter));
-                ImVec2 p_max(node_screen_pos.x + node_width + (2.0f + jitter), node_screen_pos.y + node_height + (2.0f + jitter));
-                
-                draw_list->AddRect(p_min, p_max, IM_COL32(r, g, b, (int)(180 * pulse)), Theme::ROUNDING_MD * ui_state.zoom, 0, 3.0f * ui_state.zoom);
-                draw_list->AddRect(p_min, p_max, IM_COL32(255, 255, 255, (int)(220 * pulse)), Theme::ROUNDING_MD * ui_state.zoom, 0, 1.0f * ui_state.zoom);
-            } else {
-                // --- ELECTRIC HIGH-RAIL BYPASS PATH ---
-                // Rectangular "bridge" with CONSISTENT glow style
-                float rail_height = 65.0f * ui_state.zoom;
-                float rail_y = node_screen_pos.y - rail_height;
-                
-                ImVec2 p_rail_in(flow_p1.x, rail_y);
-                ImVec2 p_rail_out(flow_p2.x, rail_y);
-                auto draw_consistent_glow_line = [&](ImVec2 p1, ImVec2 p2) {
-                    ImVec2 p1j(p1.x, p1.y + jitter);
-                    ImVec2 p2j(p2.x, p2.y + jitter);
-                    draw_list->AddLine(p1j, p2j, IM_COL32(r, g, b, (int)(180 * pulse)), 4.0f * ui_state.zoom);
-                    draw_list->AddLine(p1j, p2j, IM_COL32(255, 255, 255, (int)(220 * pulse)), 1.5f * ui_state.zoom);
-                };
-                // Bridge segments
-                draw_consistent_glow_line(flow_p1, p_rail_in);
-                draw_consistent_glow_line(p_rail_in, p_rail_out);
-                draw_consistent_glow_line(p_rail_out, flow_p2);
-                // --- MOVING ELECTRONS (PULSES) ---
-                // Electrons travel along the bridge path: Up -> Across -> Down
-                float electron_time = std::fmod(time * 2.5f, 1.0f);
-                for (int e = 0; e < 2; ++e) {
-                    float t = std::fmod(electron_time + e * 0.5f, 1.0f);
-                    ImVec2 electron_pos;
-                    
-                    if (t < 0.2f) { // Segment 1: Up
-                        float st = t / 0.2f;
-                        electron_pos = ImVec2(flow_p1.x, flow_p1.y + (rail_y - flow_p1.y) * st + jitter);
-                    } else if (t < 0.8f) { // Segment 2: Across
-                        float st = (t - 0.2f) / 0.6f;
-                        electron_pos = ImVec2(p_rail_in.x + (p_rail_out.x - p_rail_in.x) * st, rail_y + jitter);
-                    } else { // Segment 3: Down
-                        float st = (t - 0.8f) / 0.2f;
-                        electron_pos = ImVec2(p_rail_out.x, rail_y + (flow_p2.y - rail_y) * st + jitter);
-                    }
-                    
-                    draw_list->AddCircleFilled(electron_pos, 3.5f * ui_state.zoom, IM_COL32(255, 255, 255, (int)(220 * pulse)));
-                    draw_list->AddCircle(electron_pos, 7.0f * ui_state.zoom, IM_COL32(r, g, b, (int)(180 * pulse)), 0, 2.0f * ui_state.zoom);
-                }
-                if (ImGui::IsMouseHoveringRect(ImVec2(node_screen_pos.x, rail_y - 10), flow_p2)) {
-                    ImGui::SetTooltip("%s (Bypassed - High Rail Signal Path)", target_widget->get_effect()->name());
-                }
-            }
-            if (ImGui::IsMouseHoveringRect(flow_p1, flow_p2) && (target_widget || !node.name.empty())) {
-                const char* name = target_widget ? target_widget->get_effect()->name() : node.name.c_str();
-                ImGui::SetTooltip("%s (%s)", name, enabled ? "Active" : "Bypassed");
-            }
-        }
-        // ====================================================================
-        // THE DELETION [X] BUTTON
-        // ====================================================================
-        bool is_amp = (node.name == "Amp Sim"); 
-        bool is_input_node = (node.name == "Input");
-        if (!is_amp && !is_input_node) {
-            ImVec2 cross_pos = ImVec2(node_screen_pos.x + node_width - 24.0f * ui_state.zoom, node_screen_pos.y + 4.0f * ui_state.zoom);
-            ImGui::SetCursorScreenPos(cross_pos);
-            
-            // Your exact color styling
-            ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.0f, 0.0f, 0.0f, 0.0f));
-            ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.6f, 0.1f, 0.1f, 0.8f));
-            
-            // Use SmallButton and exact string formatting
-            std::string remove_label = "X##rm" + std::to_string(node.id);
-            ImGui::SetNextItemAllowOverlap();
-            if (ImGui::SmallButton(remove_label.c_str())) {
-                node_to_delete = node.id;
-            }
-            if (ImGui::IsItemHovered()) {
-                ImGui::SetTooltip("Remove %s from chain", node.name.c_str());
-            }
-            
-            ImGui::PopStyleColor(2);
-        }
-        // ====================================================================
-        // FIX: THE WIRE DROP ZONE (Input Pins)
-        // ====================================================================
-        if (!is_input_node) {
-            for (size_t idx = 0; idx < node.input_pin_ids.size(); ++idx) {
-                int pin_id = node.input_pin_ids[idx];
-                float pin_y = node_screen_pos.y + (node_height * (idx + 1.0f) / (node.input_pin_ids.size() + 1.0f));
-                ImVec2 pin_pos(node_screen_pos.x - 2.0f * ui_state.zoom, pin_y); 
-                pin_positions_cache[pin_id] = pin_pos;
-                draw_list->AddCircleFilled(pin_pos, 5.0f * ui_state.zoom, IM_COL32(46, 204, 113, 255)); 
-                draw_list->AddCircle(pin_pos, 6.5f * ui_state.zoom, IM_COL32(255, 255, 255, 200));
-                ImGui::SetCursorScreenPos(ImVec2(pin_pos.x - 10.0f * ui_state.zoom, pin_pos.y - 10.0f * ui_state.zoom));
-                ImGui::PushID(pin_id);
-                ImGui::SetNextItemAllowOverlap();
-                ImGui::InvisibleButton("in_pin", ImVec2(20.0f * ui_state.zoom, 20.0f * ui_state.zoom));
-                
-                // Check if hovered while releasing a dragged wire
-                ImVec2 mouse_pos = ImGui::GetMousePos();
-                float dist_sq = pow(mouse_pos.x - pin_pos.x, 2) + pow(mouse_pos.y - pin_pos.y, 2);
-                if (dist_sq < pow(15.0f * ui_state.zoom, 2) && ImGui::IsMouseReleased(ImGuiMouseButton_Left)) {
-                    printf("MANUAL DROP HOVER DETECTED! src: %d, dest: %d\n", ui_state.active_src_pin_id, pin_id);
-                    if (ui_state.active_src_pin_id != -1) {
-                        history_.execute(std::make_unique<AddGraphLinkCommand>(engine_, ui_state.active_src_pin_id, pin_id));
-                        ui_state.active_src_pin_id = -1;
-                    }
-                }
-                ImGui::PopID();
-            }
-        }
-        // ====================================================================
-        // FIX: THE WIRE DRAG START (Output Pins)
-        // ====================================================================
-        if (!is_amp) {
-            for (size_t idx = 0; idx < node.output_pin_ids.size(); ++idx) {
-                int pin_id = node.output_pin_ids[idx];
-                float pin_y = node_screen_pos.y + (node_height * (idx + 1.0f) / (node.output_pin_ids.size() + 1.0f));
-                ImVec2 pin_pos(node_screen_pos.x + node_width + 2.0f * ui_state.zoom, pin_y);
-                pin_positions_cache[pin_id] = pin_pos;
-                // Track active wire position to snap to the pin perfectly
-                if (ui_state.active_src_pin_id == pin_id) ui_state.active_src_pin_pos = pin_pos;
-                draw_list->AddCircleFilled(pin_pos, 5.0f * ui_state.zoom, IM_COL32(231, 76, 60, 255)); 
-                draw_list->AddCircle(pin_pos, 6.5f * ui_state.zoom, IM_COL32(255, 255, 255, 200));
-                ImGui::SetCursorScreenPos(ImVec2(pin_pos.x - 10.0f * ui_state.zoom, pin_pos.y - 10.0f * ui_state.zoom));
-                ImGui::PushID(pin_id);
-                ImGui::SetNextItemAllowOverlap();
-                ImGui::InvisibleButton("out_pin", ImVec2(20.0f * ui_state.zoom, 20.0f * ui_state.zoom));
-                
-                // Start drafting wire instantly on Mouse DOWN or delete on right click
-                if (ImGui::IsItemHovered()) {
-                    if (ImGui::IsMouseClicked(ImGuiMouseButton_Left)) {
-                        ui_state.active_src_pin_id = pin_id;
-                        ui_state.active_src_pin_pos = pin_pos;
-                    } else if (ImGui::IsMouseClicked(ImGuiMouseButton_Right)) {
-                        auto links = audio_graph.get_links(); // copy
-                        for (const auto& l : links) {
-                            if (l.source_pin_id == pin_id) {
-                                history_.execute(std::make_unique<RemoveGraphLinkCommand>(engine_, l));
-                            }
-                        }
-                    }
-                }
-                ImGui::PopID();
-            }
+    // ====================================================================
+    // FIX: THE WIRE DROP ZONE (Input Pins)
+    // ====================================================================
+    if (!is_input_node) {
+      for (size_t idx = 0; idx < node.input_pin_ids.size(); ++idx) {
+        int pin_id = node.input_pin_ids[idx];
+        float pin_y = node_screen_pos.y + (node_height * (idx + 1.0f) /
+                                           (node.input_pin_ids.size() + 1.0f));
+        ImVec2 pin_pos(node_screen_pos.x - 2.0f * ui_state.zoom, pin_y);
+        pin_positions_cache[pin_id] = pin_pos;
+        draw_list->AddCircleFilled(pin_pos, 5.0f * ui_state.zoom,
+                                   IM_COL32(46, 204, 113, 255));
+        draw_list->AddCircle(pin_pos, 6.5f * ui_state.zoom,
+                             IM_COL32(255, 255, 255, 200));
+        ImGui::SetCursorScreenPos(ImVec2(pin_pos.x - 10.0f * ui_state.zoom,
+                                         pin_pos.y - 10.0f * ui_state.zoom));
+        ImGui::PushID(pin_id);
+        ImGui::SetNextItemAllowOverlap();
+        ImGui::InvisibleButton(
+            "in_pin", ImVec2(20.0f * ui_state.zoom, 20.0f * ui_state.zoom));
+
+        // Check if hovered while releasing a dragged wire
+        ImVec2 mouse_pos = ImGui::GetMousePos();
+        float dist_sq =
+            pow(mouse_pos.x - pin_pos.x, 2) + pow(mouse_pos.y - pin_pos.y, 2);
+        if (dist_sq < pow(15.0f * ui_state.zoom, 2) &&
+            ImGui::IsMouseReleased(ImGuiMouseButton_Left)) {
+          printf("MANUAL DROP HOVER DETECTED! src: %d, dest: %d\n",
+                 ui_state.active_src_pin_id, pin_id);
+          if (ui_state.active_src_pin_id != -1) {
+            history_.execute(std::make_unique<AddGraphLinkCommand>(
+                engine_, ui_state.active_src_pin_id, pin_id));
+            ui_state.active_src_pin_id = -1;
+          }
         }
         ImGui::PopID();
+      }
     }
-    // Process Deletions safely after iterating
-    if (node_to_delete != -1) {
-        auto* node_ptr = audio_graph.find_node(node_to_delete);
-        if (node_ptr && node_ptr->routing_type == NodeRoutingType::StandardEffect) {
-            auto& effects = engine_.effects();
-            for (size_t i = 0; i < effects.size(); ++i) {
-                if (effects[i] == node_ptr->pedal) {
-                    history_.execute(std::make_unique<RemoveEffectCommand>(engine_, static_cast<int>(i)));
-                    rebuild_widgets();
-                    break;
-                }
+    // ====================================================================
+    // FIX: THE WIRE DRAG START (Output Pins)
+    // ====================================================================
+    if (!is_amp) {
+      for (size_t idx = 0; idx < node.output_pin_ids.size(); ++idx) {
+        int pin_id = node.output_pin_ids[idx];
+        float pin_y = node_screen_pos.y + (node_height * (idx + 1.0f) /
+                                           (node.output_pin_ids.size() + 1.0f));
+        ImVec2 pin_pos(node_screen_pos.x + node_width + 2.0f * ui_state.zoom,
+                       pin_y);
+        pin_positions_cache[pin_id] = pin_pos;
+        // Track active wire position to snap to the pin perfectly
+        if (ui_state.active_src_pin_id == pin_id)
+          ui_state.active_src_pin_pos = pin_pos;
+        draw_list->AddCircleFilled(pin_pos, 5.0f * ui_state.zoom,
+                                   IM_COL32(231, 76, 60, 255));
+        draw_list->AddCircle(pin_pos, 6.5f * ui_state.zoom,
+                             IM_COL32(255, 255, 255, 200));
+        ImGui::SetCursorScreenPos(ImVec2(pin_pos.x - 10.0f * ui_state.zoom,
+                                         pin_pos.y - 10.0f * ui_state.zoom));
+        ImGui::PushID(pin_id);
+        ImGui::SetNextItemAllowOverlap();
+        ImGui::InvisibleButton(
+            "out_pin", ImVec2(20.0f * ui_state.zoom, 20.0f * ui_state.zoom));
+
+        // Start drafting wire instantly on Mouse DOWN or delete on right click
+        if (ImGui::IsItemHovered()) {
+          if (ImGui::IsMouseClicked(ImGuiMouseButton_Left)) {
+            ui_state.active_src_pin_id = pin_id;
+            ui_state.active_src_pin_pos = pin_pos;
+          } else if (ImGui::IsMouseClicked(ImGuiMouseButton_Right)) {
+            auto links = audio_graph.get_links(); // copy
+            for (const auto &l : links) {
+              if (l.source_pin_id == pin_id) {
+                history_.execute(
+                    std::make_unique<RemoveGraphLinkCommand>(engine_, l));
+              }
             }
-        } else if (node_ptr) {
-            history_.execute(std::make_unique<RemoveGraphNodeCommand>(engine_, node_to_delete, node_ptr->routing_type, ui_state.node_positions[node_to_delete].position));
+          }
         }
-        ui_state.node_positions.erase(node_to_delete);
-        ui_state.active_src_pin_id = -1; // avoid stale pin state after topology change
+        ImGui::PopID();
+      }
     }
-    // Draw Patch Cables
-    int link_to_delete = -1;
-    for (const auto& link : audio_graph.get_links()) {
-        if (pin_positions_cache.count(link.source_pin_id) && pin_positions_cache.count(link.dest_pin_id)) {
-            ImVec2 p1 = pin_positions_cache[link.source_pin_id];
-            ImVec2 p2 = pin_positions_cache[link.dest_pin_id];
-            
-            ImVec2 cp1 = ImVec2(p1.x + 45.0f * ui_state.zoom, p1.y);
-            ImVec2 cp2 = ImVec2(p2.x - 45.0f * ui_state.zoom, p2.y);
-            // Distance detection for hovering/clicking
-            bool hovered = false;
-            ImVec2 mouse_pos = ImGui::GetMousePos();
-            for (float t = 0.0f; t <= 1.0f; t += 0.1f) {
-                float u = 1.0f - t;
-                float px = (u*u*u) * p1.x + (3*u*u*t) * cp1.x + (3*u*t*t) * cp2.x + (t*t*t) * p2.x;
-                float py = (u*u*u) * p1.y + (3*u*u*t) * cp1.y + (3*u*t*t) * cp2.y + (t*t*t) * p2.y;
-                float dx = px - mouse_pos.x;
-                float dy = py - mouse_pos.y;
-                if (dx * dx + dy * dy < 100.0f * ui_state.zoom * ui_state.zoom) {
-                    hovered = true;
-                    break;
-                }
-            }
-            ImU32 color = hovered ? IM_COL32(255, 100, 100, 255) : IM_COL32(212, 175, 55, 255);
-            draw_list->AddBezierCubic(p1, cp1, cp2, p2, color, hovered ? 5.0f * ui_state.zoom : 3.0f * ui_state.zoom);
-            // --- Signal Pulse Animation on Cables ---
-            if (is_running) {
-                float t_off = std::fmod(time * 2.0f, 1.0f); // Slightly faster
-                for (int step = 0; step < 4; ++step) { // More pulses
-                    float t = std::fmod(t_off + step * 0.25f, 1.0f);
-                    float u = 1.0f - t;
-                    float hx = (u*u*u) * p1.x + (3*u*u*t) * cp1.x + (3*u*t*t) * cp2.x + (t*t*t) * p2.x;
-                    float hy = (u*u*u) * p1.y + (3*u*u*t) * cp1.y + (3*u*t*t) * cp2.y + (t*t*t) * p2.y;
-                    
-                    // Larger, more vibrant pulse
-                    float pulse_size = (3.0f + 2.0f * level) * ui_state.zoom;
-                    draw_list->AddCircleFilled(ImVec2(hx, hy), pulse_size, Theme::ACCENT_GOLD_HOT);
-                    draw_list->AddCircle(ImVec2(hx, hy), pulse_size + 1.0f * ui_state.zoom, IM_COL32(255, 255, 255, 150));
-                }
-            }
-            if (hovered && ImGui::IsMouseClicked(ImGuiMouseButton_Left)) {
-                link_to_delete = link.id;
-            }
+    ImGui::PopID();
+  }
+  // Process Deletions safely after iterating
+  if (node_to_delete != -1) {
+    auto *node_ptr = audio_graph.find_node(node_to_delete);
+    if (node_ptr && node_ptr->routing_type == NodeRoutingType::StandardEffect) {
+      auto &effects = engine_.effects();
+      for (size_t i = 0; i < effects.size(); ++i) {
+        if (effects[i] == node_ptr->pedal) {
+          history_.execute(std::make_unique<RemoveEffectCommand>(
+              engine_, static_cast<int>(i)));
+          rebuild_widgets();
+          break;
         }
+      }
+    } else if (node_ptr) {
+      history_.execute(std::make_unique<RemoveGraphNodeCommand>(
+          engine_, node_to_delete, node_ptr->routing_type,
+          ui_state.node_positions[node_to_delete].position));
     }
-    
-    if (link_to_delete != -1) {
-        for (const auto& l : audio_graph.get_links()) {
-            if (l.id == link_to_delete) {
-                history_.execute(std::make_unique<RemoveGraphLinkCommand>(engine_, l));
-                break;
-            }
+    ui_state.node_positions.erase(node_to_delete);
+    ui_state.active_src_pin_id =
+        -1; // avoid stale pin state after topology change
+  }
+  // Draw Patch Cables
+  int link_to_delete = -1;
+  for (const auto &link : audio_graph.get_links()) {
+    if (pin_positions_cache.count(link.source_pin_id) &&
+        pin_positions_cache.count(link.dest_pin_id)) {
+      ImVec2 p1 = pin_positions_cache[link.source_pin_id];
+      ImVec2 p2 = pin_positions_cache[link.dest_pin_id];
+
+      ImVec2 cp1 = ImVec2(p1.x + 45.0f * ui_state.zoom, p1.y);
+      ImVec2 cp2 = ImVec2(p2.x - 45.0f * ui_state.zoom, p2.y);
+      // Distance detection for hovering/clicking
+      bool hovered = false;
+      ImVec2 mouse_pos = ImGui::GetMousePos();
+      for (float t = 0.0f; t <= 1.0f; t += 0.1f) {
+        float u = 1.0f - t;
+        float px = (u * u * u) * p1.x + (3 * u * u * t) * cp1.x +
+                   (3 * u * t * t) * cp2.x + (t * t * t) * p2.x;
+        float py = (u * u * u) * p1.y + (3 * u * u * t) * cp1.y +
+                   (3 * u * t * t) * cp2.y + (t * t * t) * p2.y;
+        float dx = px - mouse_pos.x;
+        float dy = py - mouse_pos.y;
+        if (dx * dx + dy * dy < 100.0f * ui_state.zoom * ui_state.zoom) {
+          hovered = true;
+          break;
         }
-    }
-    // Draw Wire Spline Drafting
-    if (ui_state.active_src_pin_id != -1) {
-        ImVec2 mouse_pos = ImGui::GetMousePos();
-        ImVec2 p1 = ui_state.active_src_pin_pos;
-        ImVec2 cp1 = ImVec2(p1.x + 45.0f, p1.y);
-        ImVec2 cp2 = ImVec2(mouse_pos.x - 45.0f, mouse_pos.y);
-        draw_list->AddBezierCubic(p1, cp1, cp2, mouse_pos, IM_COL32(255, 255, 255, 160), 2.0f, 0);
-        if (ImGui::IsMouseReleased(ImGuiMouseButton_Left)) {
-            ui_state.active_src_pin_id = -1; // Snap cable back if dropped in empty space
+      }
+      ImU32 color =
+          hovered ? IM_COL32(255, 100, 100, 255) : IM_COL32(212, 175, 55, 255);
+      draw_list->AddBezierCubic(p1, cp1, cp2, p2, color,
+                                hovered ? 5.0f * ui_state.zoom
+                                        : 3.0f * ui_state.zoom);
+      // --- Signal Pulse Animation on Cables ---
+      if (is_running) {
+        float t_off = std::fmod(time * 2.0f, 1.0f); // Slightly faster
+        for (int step = 0; step < 4; ++step) {      // More pulses
+          float t = std::fmod(t_off + step * 0.25f, 1.0f);
+          float u = 1.0f - t;
+          float hx = (u * u * u) * p1.x + (3 * u * u * t) * cp1.x +
+                     (3 * u * t * t) * cp2.x + (t * t * t) * p2.x;
+          float hy = (u * u * u) * p1.y + (3 * u * u * t) * cp1.y +
+                     (3 * u * t * t) * cp2.y + (t * t * t) * p2.y;
+
+          // Larger, more vibrant pulse
+          float pulse_size = (3.0f + 2.0f * level) * ui_state.zoom;
+          draw_list->AddCircleFilled(ImVec2(hx, hy), pulse_size,
+                                     Theme::ACCENT_GOLD_HOT);
+          draw_list->AddCircle(ImVec2(hx, hy),
+                               pulse_size + 1.0f * ui_state.zoom,
+                               IM_COL32(255, 255, 255, 150));
         }
+      }
+      if (hovered && ImGui::IsMouseClicked(ImGuiMouseButton_Left)) {
+        link_to_delete = link.id;
+      }
     }
-    // Fix ImGui cursor bounds warnings after free panning
-    ImGui::SetCursorPos(ImVec2(0, 0));
-    ImGui::Dummy(canvas_size);
-    draw_list->PopClipRect();
+  }
+
+  if (link_to_delete != -1) {
+    for (const auto &l : audio_graph.get_links()) {
+      if (l.id == link_to_delete) {
+        history_.execute(std::make_unique<RemoveGraphLinkCommand>(engine_, l));
+        break;
+      }
+    }
+  }
+  // Draw Wire Spline Drafting
+  if (ui_state.active_src_pin_id != -1) {
+    ImVec2 mouse_pos = ImGui::GetMousePos();
+    ImVec2 p1 = ui_state.active_src_pin_pos;
+    ImVec2 cp1 = ImVec2(p1.x + 45.0f, p1.y);
+    ImVec2 cp2 = ImVec2(mouse_pos.x - 45.0f, mouse_pos.y);
+    draw_list->AddBezierCubic(p1, cp1, cp2, mouse_pos,
+                              IM_COL32(255, 255, 255, 160), 2.0f, 0);
+    if (ImGui::IsMouseReleased(ImGuiMouseButton_Left)) {
+      ui_state.active_src_pin_id =
+          -1; // Snap cable back if dropped in empty space
+    }
+  }
+  // Fix ImGui cursor bounds warnings after free panning
+  ImGui::SetCursorPos(ImVec2(0, 0));
+  ImGui::Dummy(canvas_size);
+  draw_list->PopClipRect();
 }
 } // namespace Amplitron

--- a/src/gui/pedalboard/pedal_board_chain.cpp
+++ b/src/gui/pedalboard/pedal_board_chain.cpp
@@ -215,6 +215,11 @@ void PedalBoard::render_signal_chain() {
       node_height =
           std::max(70.0f, (float)node.input_pin_ids.size() * 32.0f + 55.0f) *
           ui_state.zoom;
+    } else if (!target_widget && node.routing_type == NodeRoutingType::Splitter) {
+      node_width = 130.0f * ui_state.zoom;
+      node_height =
+          std::max(70.0f, (float)node.output_pin_ids.size() * 32.0f + 55.0f) *
+          ui_state.zoom;
     }
     ImGui::PushID(node.id);
     if (target_widget) {

--- a/src/gui/pedalboard/pedal_board_chain.cpp
+++ b/src/gui/pedalboard/pedal_board_chain.cpp
@@ -54,11 +54,7 @@ void PedalBoard::render_signal_chain() {
       ImVec2(canvas_pos.x + canvas_size.x, canvas_pos.y + canvas_size.y);
   ui_state.last_canvas_pos = canvas_pos;
   ImGui::SetCursorScreenPos(canvas_pos);
-  ImGuiButtonFlags btn_flags =
-      ImGuiButtonFlags_MouseButtonRight | ImGuiButtonFlags_MouseButtonMiddle;
-  if (ui_state.hand_tool_active) {
-    btn_flags |= ImGuiButtonFlags_MouseButtonLeft;
-  }
+  ImGuiButtonFlags btn_flags = ImGuiButtonFlags_MouseButtonRight | ImGuiButtonFlags_MouseButtonMiddle | ImGuiButtonFlags_MouseButtonLeft;
 
   ImGui::SetNextItemAllowOverlap();
   if (canvas_size.x <= 0.0f) canvas_size.x = 1.0f;
@@ -68,19 +64,15 @@ void PedalBoard::render_signal_chain() {
   // actual canvas item
   ui_state.canvas_hovered = ImGui::IsItemHovered();
 
-  if (ui_state.hand_tool_active && ImGui::IsItemHovered()) {
+  if (ImGui::IsItemHovered() && !ImGui::IsAnyItemHovered()) {
     ImGui::SetMouseCursor(ImGuiMouseCursor_Hand);
   }
 
-  if (ImGui::IsItemActive() &&
-      (ImGui::IsMouseDragging(ImGuiMouseButton_Right) ||
-       ImGui::IsMouseDragging(ImGuiMouseButton_Middle) ||
-       (ui_state.hand_tool_active &&
-        ImGui::IsMouseDragging(ImGuiMouseButton_Left)))) {
-    ui_state.scrolling.x +=
-        ImGui::GetIO().MousePos.x - ImGui::GetIO().MousePosPrev.x;
-    ui_state.scrolling.y +=
-        ImGui::GetIO().MousePos.y - ImGui::GetIO().MousePosPrev.y;
+  if (ImGui::IsItemActive() && (ImGui::IsMouseDragging(ImGuiMouseButton_Right) || 
+                                ImGui::IsMouseDragging(ImGuiMouseButton_Middle) || 
+                                ImGui::IsMouseDragging(ImGuiMouseButton_Left))) {
+    ui_state.scrolling.x += ImGui::GetIO().MouseDelta.x;
+    ui_state.scrolling.y += ImGui::GetIO().MouseDelta.y;
     ui_state.target_scrolling = ui_state.scrolling;
   }
   // Zooming is now allowed in both fullscreen and normal modes
@@ -149,34 +141,6 @@ void PedalBoard::render_signal_chain() {
   for (auto &pair : ui_state.node_positions) {
     if (!audio_graph.find_node(pair.first)) {
       stale_ids.push_back(pair.first);
-    auto& audio_graph = engine_.graph(); 
-    ImDrawList* draw_list = ImGui::GetWindowDrawList();
-    ImVec2 canvas_pos = ImGui::GetCursorScreenPos();
-    ImVec2 canvas_size = ImGui::GetContentRegionAvail();
-    ImVec2 canvas_end = ImVec2(canvas_pos.x + canvas_size.x, canvas_pos.y + canvas_size.y);
-    ui_state.last_canvas_pos = canvas_pos;
-    ImGui::SetCursorScreenPos(canvas_pos);
-    // Left mouse button always pans the canvas on empty space. Widgets (knobs,
-    // drag handles, pins) are rendered on top and capture clicks first — this
-    // InvisibleButton only receives clicks that fall through to empty canvas.
-    ImGuiButtonFlags btn_flags = ImGuiButtonFlags_MouseButtonRight | ImGuiButtonFlags_MouseButtonMiddle | ImGuiButtonFlags_MouseButtonLeft;
-    
-    ImGui::SetNextItemAllowOverlap();
-    ImGui::InvisibleButton("canvas_panning_hotspot", canvas_size, btn_flags);
-    // Update canvas_hovered here — after InvisibleButton — so it reflects the actual canvas item
-    ui_state.canvas_hovered = ImGui::IsItemHovered();
-    
-    // Show hand cursor only when hovering empty canvas (no widget underneath)
-    if (ImGui::IsItemHovered() && !ImGui::IsAnyItemHovered()) {
-        ImGui::SetMouseCursor(ImGuiMouseCursor_Hand);
-    }
-    
-    if (ImGui::IsItemActive() && (ImGui::IsMouseDragging(ImGuiMouseButton_Right) || 
-                                  ImGui::IsMouseDragging(ImGuiMouseButton_Middle) || 
-                                  ImGui::IsMouseDragging(ImGuiMouseButton_Left))) {
-        ui_state.scrolling.x += ImGui::GetIO().MouseDelta.x;
-        ui_state.scrolling.y += ImGui::GetIO().MouseDelta.y;
-        ui_state.target_scrolling = ui_state.scrolling;
     }
   }
   for (int id : stale_ids) {
@@ -188,7 +152,7 @@ void PedalBoard::render_signal_chain() {
     if (ui_state.node_positions.find(node.id) ==
         ui_state.node_positions.end()) {
       if (node.x != 0.0f || node.y != 0.0f) {
-        ui_state.node_positions[node.id] = {ImVec2(node.x, node.y), false};
+        ui_state.node_positions[node.id] = {ImVec2(node.x, node.y), false, ImVec2(0, 0)};
       } else {
         float max_right = 40.0f;
         for (const auto &existing_node : audio_graph.get_nodes()) {
@@ -206,7 +170,7 @@ void PedalBoard::render_signal_chain() {
         }
         float insert_x =
             ui_state.node_positions.empty() ? 40.0f : max_right + 80.0f;
-        ui_state.node_positions[node.id] = {ImVec2(insert_x, 60.0f), false};
+        ui_state.node_positions[node.id] = {ImVec2(insert_x, 60.0f), false, ImVec2(0, 0)};
       }
     }
   }
@@ -262,8 +226,7 @@ void PedalBoard::render_signal_chain() {
       ImGui::InvisibleButton(
           "native_drag_handle",
           ImVec2(node_width - 25.0f * ui_state.zoom, 30.0f * ui_state.zoom));
-      if (!ui_state.hand_tool_active && ImGui::IsItemActive() &&
-          ImGui::IsMouseDragging(ImGuiMouseButton_Left)) {
+      if (ImGui::IsItemActive() && ImGui::IsMouseDragging(ImGuiMouseButton_Left)) {
         if (!node_layout.is_dragging) {
           node_layout.is_dragging = true;
           node_layout.drag_start_pos = node_layout.position;
@@ -292,8 +255,7 @@ void PedalBoard::render_signal_chain() {
       ImGui::InvisibleButton(
           "util_drag_handle",
           ImVec2(node_width - 25.0f * ui_state.zoom, node_height));
-      if (!ui_state.hand_tool_active && ImGui::IsItemActive() &&
-          ImGui::IsMouseDragging(ImGuiMouseButton_Left)) {
+      if (ImGui::IsItemActive() && ImGui::IsMouseDragging(ImGuiMouseButton_Left)) {
         if (!node_layout.is_dragging) {
           node_layout.is_dragging = true;
           node_layout.drag_start_pos = node_layout.position;
@@ -306,59 +268,13 @@ void PedalBoard::render_signal_chain() {
             node_layout.position.y != node_layout.drag_start_pos.y) {
           history_.push_executed(std::make_unique<MoveGraphNodeCommand>(
               node.id, node_layout.drag_start_pos, node_layout.position));
-        float node_width = (target_widget ? (is_mb_comp ? 190.0f * 2.2f : 190.0f) : 110.0f) * ui_state.zoom;
-        float node_height = (target_widget ? 360.0f : 70.0f) * ui_state.zoom;
-        ImGui::PushID(node.id);
-        if (target_widget) {
-            ImGui::SetCursorScreenPos(node_screen_pos);
-            ImGui::BeginGroup();
-            ImGui::SetWindowFontScale(ui_state.zoom);
-            target_widget->render(ui_state.zoom); 
-            ImGui::SetWindowFontScale(1.0f);
-            ImGui::EndGroup();
-            ImGui::SetCursorScreenPos(node_screen_pos);
-            ImGui::SetNextItemAllowOverlap(); 
-            ImGui::InvisibleButton("native_drag_handle", ImVec2(node_width - 25.0f * ui_state.zoom, 30.0f * ui_state.zoom));
-            if (ImGui::IsItemActive() && ImGui::IsMouseDragging(ImGuiMouseButton_Left)) {
-                if (!node_layout.is_dragging) {
-                    node_layout.is_dragging = true;
-                    node_layout.drag_start_pos = node_layout.position;
-                }
-                node_layout.position.x += ImGui::GetIO().MouseDelta.x / ui_state.zoom;
-                node_layout.position.y += ImGui::GetIO().MouseDelta.y / ui_state.zoom;
-            } else if (node_layout.is_dragging && ImGui::IsItemDeactivated()) {
-                node_layout.is_dragging = false;
-                if (node_layout.position.x != node_layout.drag_start_pos.x || node_layout.position.y != node_layout.drag_start_pos.y) {
-                    history_.push_executed(std::make_unique<MoveGraphNodeCommand>(node.id, node_layout.drag_start_pos, node_layout.position));
-                }
-            }
-        } else {
-            ImVec2 node_end = ImVec2(node_screen_pos.x + node_width, node_screen_pos.y + node_height);
-            ImU32 bg_color = IM_COL32(50, 35, 60, 255);
-            draw_list->AddRectFilled(node_screen_pos, node_end, bg_color, Theme::ROUNDING_MD * ui_state.zoom);
-            draw_list->AddRect(node_screen_pos, node_end, IM_COL32(180, 140, 80, 180), Theme::ROUNDING_MD * ui_state.zoom, 0, 1.5f * ui_state.zoom);
-            ImGui::SetCursorScreenPos(node_screen_pos);
-            ImGui::SetNextItemAllowOverlap();
-            ImGui::InvisibleButton("util_drag_handle", ImVec2(node_width - 25.0f * ui_state.zoom, node_height));
-            if (ImGui::IsItemActive() && ImGui::IsMouseDragging(ImGuiMouseButton_Left)) {
-                if (!node_layout.is_dragging) {
-                    node_layout.is_dragging = true;
-                    node_layout.drag_start_pos = node_layout.position;
-                }
-                node_layout.position.x += ImGui::GetIO().MouseDelta.x / ui_state.zoom;
-                node_layout.position.y += ImGui::GetIO().MouseDelta.y / ui_state.zoom;
-            } else if (node_layout.is_dragging && ImGui::IsItemDeactivated()) {
-                node_layout.is_dragging = false;
-                if (node_layout.position.x != node_layout.drag_start_pos.x || node_layout.position.y != node_layout.drag_start_pos.y) {
-                    history_.push_executed(std::make_unique<MoveGraphNodeCommand>(node.id, node_layout.drag_start_pos, node_layout.position));
-                }
-            }
-            ImVec2 text_pos = ImVec2(node_screen_pos.x + 12.0f * ui_state.zoom, node_screen_pos.y + 25.0f * ui_state.zoom);
-            ImGui::SetWindowFontScale(ui_state.zoom);
-            draw_list->AddText(text_pos, IM_COL32(255, 255, 255, 255), node.name.c_str());
-            ImGui::SetWindowFontScale(1.0f);
         }
       }
+      ImVec2 text_pos = ImVec2(node_screen_pos.x + 12.0f * ui_state.zoom, node_screen_pos.y + 25.0f * ui_state.zoom);
+      ImGui::SetWindowFontScale(ui_state.zoom);
+      draw_list->AddText(text_pos, IM_COL32(255, 255, 255, 255), node.name.c_str());
+      ImGui::SetWindowFontScale(1.0f);
+    }
 
       bool is_mixer = (node.routing_type == NodeRoutingType::Mixer ||
                        node.routing_type == NodeRoutingType::MergeSum);
@@ -445,7 +361,6 @@ void PedalBoard::render_signal_chain() {
         ImGui::TextDisabled("(Gain Fader)");
         ImGui::SetWindowFontScale(1.0f);
       }
-    }
     if (!node.is_reachable) {
       ImVec2 node_end = ImVec2(node_screen_pos.x + node_width,
                                node_screen_pos.y + node_height);

--- a/src/gui/pedalboard/pedal_board_chain.cpp
+++ b/src/gui/pedalboard/pedal_board_chain.cpp
@@ -342,11 +342,8 @@ void PedalBoard::render_signal_chain() {
             std::string effect_name = "Mixer_" + std::to_string(node.id);
             std::string param_name = "Gain " + std::to_string(idx);
             if (gui_midi_) {
-              if (gui_midi_->render_remove_mapping_item(effect_name,
-                                                        param_name)) {
-              }
-              if (gui_midi_->render_learn_menu_item(effect_name, param_name)) {
-              }
+              gui_midi_->render_remove_mapping_item(effect_name, param_name);
+              gui_midi_->render_learn_menu_item(effect_name, param_name);
             } else {
               ImGui::TextDisabled("MIDI manager not available");
             }
@@ -545,8 +542,6 @@ void PedalBoard::render_signal_chain() {
             pow(mouse_pos.x - pin_pos.x, 2) + pow(mouse_pos.y - pin_pos.y, 2);
         if (dist_sq < pow(15.0f * ui_state.zoom, 2) &&
             ImGui::IsMouseReleased(ImGuiMouseButton_Left)) {
-          printf("MANUAL DROP HOVER DETECTED! src: %d, dest: %d\n",
-                 ui_state.active_src_pin_id, pin_id);
           if (ui_state.active_src_pin_id != -1) {
             history_.execute(std::make_unique<AddGraphLinkCommand>(
                 engine_, ui_state.active_src_pin_id, pin_id));
@@ -692,8 +687,8 @@ void PedalBoard::render_signal_chain() {
   if (ui_state.active_src_pin_id != -1) {
     ImVec2 mouse_pos = ImGui::GetMousePos();
     ImVec2 p1 = ui_state.active_src_pin_pos;
-    ImVec2 cp1 = ImVec2(p1.x + 45.0f, p1.y);
-    ImVec2 cp2 = ImVec2(mouse_pos.x - 45.0f, mouse_pos.y);
+    ImVec2 cp1 = ImVec2(p1.x + 45.0f * ui_state.zoom, p1.y);
+    ImVec2 cp2 = ImVec2(mouse_pos.x - 45.0f * ui_state.zoom, mouse_pos.y);
     draw_list->AddBezierCubic(p1, cp1, cp2, mouse_pos,
                               IM_COL32(255, 255, 255, 160), 2.0f, 0);
     if (ImGui::IsMouseReleased(ImGuiMouseButton_Left)) {

--- a/src/gui/pedalboard/pedal_board_menu.cpp
+++ b/src/gui/pedalboard/pedal_board_menu.cpp
@@ -107,13 +107,8 @@ void PedalBoard::render_add_pedal_menu() {
         if (ImGui::MenuItem("+ Signal Splitter Node (1 In -> 2 Out)")) {
             history_.execute(std::make_unique<AddGraphNodeCommand>(engine_, "Splitter", NodeRoutingType::Splitter, nullptr, ImVec2(0, 0)));
         }
-        if (ImGui::BeginMenu("+ Signal Mixer Node (N-In -> 1 Out)")) {
-            for (int i = 2; i <= 8; ++i) {
-                if (ImGui::MenuItem((std::to_string(i) + " Inputs").c_str())) {
-                    history_.execute(std::make_unique<AddGraphNodeCommand>(engine_, "Mixer", NodeRoutingType::Mixer, nullptr, ImVec2(0, 0), i));
-                }
-            }
-            ImGui::EndMenu();
+        if (ImGui::MenuItem("+ Signal Mixer Node (N-In -> 1 Out)")) {
+            history_.execute(std::make_unique<AddGraphNodeCommand>(engine_, "Mixer", NodeRoutingType::Mixer, nullptr, ImVec2(0, 0), 2));
         }
 
         ImGui::EndPopup();

--- a/src/gui/pedalboard/pedal_board_menu.cpp
+++ b/src/gui/pedalboard/pedal_board_menu.cpp
@@ -1,222 +1,227 @@
 #include "gui/pedalboard/pedal_board.h"
+#include "gui/theme/theme.h"
 #include "gui/views/gui_midi.h"
 #include "midi/midi_manager.h"
-#include "gui/theme/theme.h"
 
-#include "audio/effects/noise_gate.h"
+#include "audio/effects/amp_simulator.h"
+#include "audio/effects/cabinet_sim.h"
+#include "audio/effects/chorus.h"
 #include "audio/effects/compressor.h"
-#include "audio/effects/multiband_compressor.h"
-#include "audio/effects/overdrive.h"
+#include "audio/effects/delay.h"
 #include "audio/effects/distortion.h"
 #include "audio/effects/equalizer.h"
-#include "audio/effects/chorus.h"
-#include "audio/effects/phaser.h"
 #include "audio/effects/flanger.h"
-#include "audio/effects/delay.h"
-#include "audio/effects/reverb.h"
 #include "audio/effects/looper.h"
-#include "audio/effects/cabinet_sim.h"
-#include "audio/effects/amp_simulator.h"
-#include "audio/effects/wah.h"
+#include "audio/effects/multiband_compressor.h"
+#include "audio/effects/noise_gate.h"
 #include "audio/effects/octaver.h"
+#include "audio/effects/overdrive.h"
+#include "audio/effects/phaser.h"
 #include "audio/effects/pitch_shifter.h"
+#include "audio/effects/reverb.h"
+#include "audio/effects/wah.h"
 
-#include <imgui.h>
 #include <cstdio>
+#include <imgui.h>
 
 namespace Amplitron {
 
 void PedalBoard::render_add_pedal_menu() {
-    if (ImGui::Button("+ Add Pedal")) {
-        ImGui::OpenPopup("AddPedalPopup");
+  if (ImGui::Button("+ Add Pedal")) {
+    ImGui::OpenPopup("AddPedalPopup");
+  }
+
+  if (ImGui::BeginPopup("AddPedalPopup")) {
+    ImGui::TextColored(Theme::Gold(), "DRIVE");
+    if (ImGui::MenuItem("Overdrive")) {
+      add_effect_and_show(std::make_shared<Overdrive>());
+    }
+    if (ImGui::MenuItem("Distortion")) {
+      add_effect_and_show(std::make_shared<Distortion>());
     }
 
-    if (ImGui::BeginPopup("AddPedalPopup")) {
-        ImGui::TextColored(Theme::Gold(), "DRIVE");
-        if (ImGui::MenuItem("Overdrive")) {
-            add_effect_and_show(std::make_shared<Overdrive>());
-        }
-        if (ImGui::MenuItem("Distortion")) {
-            add_effect_and_show(std::make_shared<Distortion>());
-        }
-
-        ImGui::Separator();
-        ImGui::TextColored(Theme::Live(), "DYNAMICS");
-        if (ImGui::MenuItem("Noise Gate")) {
-            add_effect_and_show(std::make_shared<NoiseGate>());
-        }
-        if (ImGui::MenuItem("Compressor")) {
-            add_effect_and_show(std::make_shared<Compressor>());
-        }
-        if (ImGui::MenuItem("MultiBand Compressor")) {
-            add_effect_and_show(std::make_shared<MultiBandCompressor>());
-        }
-
-        ImGui::Separator();
-        ImGui::TextColored(ImVec4(0.35f, 0.60f, 0.95f, 1.0f), "MODULATION");
-        if (ImGui::MenuItem("Chorus")) {
-            add_effect_and_show(std::make_shared<Chorus>());
-        }
-        if (ImGui::MenuItem("Phaser")) {
-            add_effect_and_show(std::make_shared<Phaser>());
-        }
-        if (ImGui::MenuItem("Flanger")) {
-            add_effect_and_show(std::make_shared<Flanger>());
-        }
-
-        ImGui::Separator();
-        ImGui::TextColored(ImVec4(0.65f, 0.35f, 0.95f, 1.0f), "TIME");
-        if (ImGui::MenuItem("Delay")) {
-            add_effect_and_show(std::make_shared<Delay>());
-        }
-        if (ImGui::MenuItem("Reverb")) {
-            add_effect_and_show(std::make_shared<Reverb>());
-        }
-        if (ImGui::MenuItem("Looper")) {
-            add_effect_and_show(std::make_shared<Looper>());
-        }
-
-        ImGui::Separator();
-        ImGui::TextColored(ImVec4(0.30f, 0.75f, 0.60f, 1.0f), "FILTER");
-        if (ImGui::MenuItem("Wah")) {
-            add_effect_and_show(std::make_shared<WahPedal>());
-        }
-
-        ImGui::Separator();
-        ImGui::TextColored(ImVec4(0.85f, 0.40f, 0.55f, 1.0f), "PITCH");
-        if (ImGui::MenuItem("Octaver")) {
-            add_effect_and_show(std::make_shared<Octaver>());
-        }
-        if (ImGui::MenuItem("Pitch Shifter")) {
-            add_effect_and_show(std::make_shared<PitchShifter>());
-        }
-
-        ImGui::Separator();
-        ImGui::TextColored(Theme::GoldDim(), "TONE");
-        if (ImGui::MenuItem("Equalizer")) {
-            add_effect_and_show(std::make_shared<Equalizer>());
-        }
-        if (ImGui::MenuItem("Cabinet Sim")) {
-            add_effect_and_show(std::make_shared<CabinetSim>());
-        }
-
-        ImGui::Separator();
-        ImGui::TextDisabled("Routing Utility Blocks");
-    
-        // --- NEW MODULAR DAG INSTANTIATION ENTRIES ---
-        if (ImGui::MenuItem("+ Signal Splitter Node (1 In -> 2 Out)")) {
-            history_.execute(std::make_unique<AddGraphNodeCommand>(engine_, "Splitter", NodeRoutingType::Splitter, nullptr, ImVec2(0, 0)));
-        }
-        if (ImGui::MenuItem("+ Signal Mixer Node (N-In -> 1 Out)")) {
-            history_.execute(std::make_unique<AddGraphNodeCommand>(engine_, "Mixer", NodeRoutingType::Mixer, nullptr, ImVec2(0, 0), 2));
-        }
-
-        ImGui::EndPopup();
+    ImGui::Separator();
+    ImGui::TextColored(Theme::Live(), "DYNAMICS");
+    if (ImGui::MenuItem("Noise Gate")) {
+      add_effect_and_show(std::make_shared<NoiseGate>());
     }
+    if (ImGui::MenuItem("Compressor")) {
+      add_effect_and_show(std::make_shared<Compressor>());
+    }
+    if (ImGui::MenuItem("MultiBand Compressor")) {
+      add_effect_and_show(std::make_shared<MultiBandCompressor>());
+    }
+
+    ImGui::Separator();
+    ImGui::TextColored(ImVec4(0.35f, 0.60f, 0.95f, 1.0f), "MODULATION");
+    if (ImGui::MenuItem("Chorus")) {
+      add_effect_and_show(std::make_shared<Chorus>());
+    }
+    if (ImGui::MenuItem("Phaser")) {
+      add_effect_and_show(std::make_shared<Phaser>());
+    }
+    if (ImGui::MenuItem("Flanger")) {
+      add_effect_and_show(std::make_shared<Flanger>());
+    }
+
+    ImGui::Separator();
+    ImGui::TextColored(ImVec4(0.65f, 0.35f, 0.95f, 1.0f), "TIME");
+    if (ImGui::MenuItem("Delay")) {
+      add_effect_and_show(std::make_shared<Delay>());
+    }
+    if (ImGui::MenuItem("Reverb")) {
+      add_effect_and_show(std::make_shared<Reverb>());
+    }
+    if (ImGui::MenuItem("Looper")) {
+      add_effect_and_show(std::make_shared<Looper>());
+    }
+
+    ImGui::Separator();
+    ImGui::TextColored(ImVec4(0.30f, 0.75f, 0.60f, 1.0f), "FILTER");
+    if (ImGui::MenuItem("Wah")) {
+      add_effect_and_show(std::make_shared<WahPedal>());
+    }
+
+    ImGui::Separator();
+    ImGui::TextColored(ImVec4(0.85f, 0.40f, 0.55f, 1.0f), "PITCH");
+    if (ImGui::MenuItem("Octaver")) {
+      add_effect_and_show(std::make_shared<Octaver>());
+    }
+    if (ImGui::MenuItem("Pitch Shifter")) {
+      add_effect_and_show(std::make_shared<PitchShifter>());
+    }
+
+    ImGui::Separator();
+    ImGui::TextColored(Theme::GoldDim(), "TONE");
+    if (ImGui::MenuItem("Equalizer")) {
+      add_effect_and_show(std::make_shared<Equalizer>());
+    }
+    if (ImGui::MenuItem("Cabinet Sim")) {
+      add_effect_and_show(std::make_shared<CabinetSim>());
+    }
+
+    ImGui::Separator();
+    ImGui::TextDisabled("Routing Utility Blocks");
+
+    // --- NEW MODULAR DAG INSTANTIATION ENTRIES ---
+    if (ImGui::MenuItem("+ Signal Splitter Node (1 In -> N-Out)")) {
+      history_.execute(std::make_unique<AddGraphNodeCommand>(
+          engine_, "Splitter", NodeRoutingType::Splitter, nullptr,
+          ImVec2(0, 0)));
+    }
+    if (ImGui::MenuItem("+ Signal Mixer Node (N-In -> 1 Out)")) {
+      history_.execute(std::make_unique<AddGraphNodeCommand>(
+          engine_, "Mixer", NodeRoutingType::Mixer, nullptr, ImVec2(0, 0), 2));
+    }
+
+    ImGui::EndPopup();
+  }
 }
 
-
 void PedalBoard::render_amp_selector() {
-    const auto& models = get_amp_models();
-    int amp_idx = find_amp_index();
+  const auto &models = get_amp_models();
+  int amp_idx = find_amp_index();
 
-    if (amp_idx < 0) {
-        auto amp = std::make_shared<AmpSimulator>();
-        amp->params()[0].value = 0.0f;
-        engine_.add_effect(amp);
-        rebuild_widgets();
-        amp_idx = find_amp_index();
+  if (amp_idx < 0) {
+    auto amp = std::make_shared<AmpSimulator>();
+    amp->params()[0].value = 0.0f;
+    engine_.add_effect(amp);
+    rebuild_widgets();
+    amp_idx = find_amp_index();
+  }
+
+  const char *current_label = "Amp";
+  int current_model = 0;
+  if (amp_idx >= 0) {
+    auto &amp_fx = engine_.effects()[amp_idx];
+    current_model = static_cast<int>(amp_fx->params()[0].value);
+    if (current_model >= 0 && current_model < static_cast<int>(models.size())) {
+      current_label = models[current_model].name;
     }
+  }
 
-    const char* current_label = "Amp";
-    int current_model = 0;
-    if (amp_idx >= 0) {
-        auto& amp_fx = engine_.effects()[amp_idx];
-        current_model = static_cast<int>(amp_fx->params()[0].value);
-        if (current_model >= 0 && current_model < static_cast<int>(models.size())) {
-            current_label = models[current_model].name;
+  ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.35f, 0.18f, 0.08f, 1.0f));
+  ImGui::PushStyleColor(ImGuiCol_ButtonHovered,
+                        ImVec4(0.50f, 0.25f, 0.10f, 1.0f));
+  char amp_label[64];
+  std::snprintf(amp_label, sizeof(amp_label), "Amp: %s", current_label);
+  if (ImGui::Button(amp_label)) {
+    ImGui::OpenPopup("AmpSelectorPopup");
+  }
+  ImGui::PopStyleColor(2);
+
+  if (ImGui::BeginPopup("AmpSelectorPopup")) {
+    ImGui::TextColored(ImVec4(0.95f, 0.55f, 0.20f, 1.0f), "AMP MODEL");
+    for (int m = 0; m < static_cast<int>(models.size()); ++m) {
+      bool is_selected = (current_model == m);
+      if (ImGui::MenuItem(models[m].name, models[m].inspiration, is_selected)) {
+        if (amp_idx >= 0) {
+          engine_.effects()[amp_idx]->params()[0].value = static_cast<float>(m);
         }
+      }
     }
-
-    ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.35f, 0.18f, 0.08f, 1.0f));
-    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.50f, 0.25f, 0.10f, 1.0f));
-    char amp_label[64];
-    std::snprintf(amp_label, sizeof(amp_label), "Amp: %s", current_label);
-    if (ImGui::Button(amp_label)) {
-        ImGui::OpenPopup("AmpSelectorPopup");
-    }
-    ImGui::PopStyleColor(2);
-
-    if (ImGui::BeginPopup("AmpSelectorPopup")) {
-        ImGui::TextColored(ImVec4(0.95f, 0.55f, 0.20f, 1.0f), "AMP MODEL");
-        for (int m = 0; m < static_cast<int>(models.size()); ++m) {
-            bool is_selected = (current_model == m);
-            if (ImGui::MenuItem(models[m].name, models[m].inspiration, is_selected)) {
-                if (amp_idx >= 0) {
-                    engine_.effects()[amp_idx]->params()[0].value = static_cast<float>(m);
-                }
-            }
-        }
-        ImGui::EndPopup();
-    }
+    ImGui::EndPopup();
+  }
 }
 
 // ============================================================
 // MIDI MENU — QUICK STATUS AND ACTIONS
 // ============================================================
 void PedalBoard::render_midi_menu() {
-    if (!gui_midi_) return;
-    auto& midi = gui_midi_->manager();
+  if (!gui_midi_)
+    return;
+  auto &midi = gui_midi_->manager();
 
-    if (ImGui::Button("MIDI")) {
-        ImGui::OpenPopup("MidiMenuPopup");
+  if (ImGui::Button("MIDI")) {
+    ImGui::OpenPopup("MidiMenuPopup");
+  }
+
+  if (ImGui::BeginPopup("MidiMenuPopup")) {
+    // Device status
+    if (midi.is_port_open()) {
+      ImGui::TextColored(ImVec4(0.0f, 1.0f, 0.0f, 1.0f), "● Connected");
+      ImGui::SameLine();
+      ImGui::TextDisabled("(%s)", midi.current_port_name().c_str());
+    } else {
+      ImGui::TextColored(ImVec4(1.0f, 0.4f, 0.4f, 1.0f), "● Disconnected");
     }
 
-    if (ImGui::BeginPopup("MidiMenuPopup")) {
-        // Device status
-        if (midi.is_port_open()) {
-            ImGui::TextColored(ImVec4(0.0f, 1.0f, 0.0f, 1.0f), "● Connected");
-            ImGui::SameLine();
-            ImGui::TextDisabled("(%s)", midi.current_port_name().c_str());
-        } else {
-            ImGui::TextColored(ImVec4(1.0f, 0.4f, 0.4f, 1.0f), "● Disconnected");
-        }
+    ImGui::Separator();
 
-        ImGui::Separator();
-
-        // Learn mode status
-        if (midi.is_learning()) {
-            ImGui::TextColored(ImVec4(1.0f, 0.8f, 0.0f, 1.0f), "⚡ Learn Mode Active");
-            if (ImGui::MenuItem("Cancel Learn Mode", "Esc")) {
-                midi.cancel_learn();
-            }
-        } else {
-            ImGui::TextDisabled("Right-click any knob to MIDI learn");
-        }
-
-        ImGui::Separator();
-
-        // Quick actions
-        if (ImGui::MenuItem("Clear All Mappings")) {
-            show_confirm_midi_clear_ = true;
-        }
-
-        if (ImGui::MenuItem("Save Config")) {
-            midi.save_config();
-        }
-
-        if (ImGui::MenuItem("Load Config")) {
-            midi.load_config();
-        }
-
-        ImGui::Separator();
-
-        // Show active mappings count
-        auto& mappings = midi.mappings();
-        ImGui::TextDisabled("%zu active mappings", mappings.size());
-
-        ImGui::EndPopup();
+    // Learn mode status
+    if (midi.is_learning()) {
+      ImGui::TextColored(ImVec4(1.0f, 0.8f, 0.0f, 1.0f),
+                         "⚡ Learn Mode Active");
+      if (ImGui::MenuItem("Cancel Learn Mode", "Esc")) {
+        midi.cancel_learn();
+      }
+    } else {
+      ImGui::TextDisabled("Right-click any knob to MIDI learn");
     }
+
+    ImGui::Separator();
+
+    // Quick actions
+    if (ImGui::MenuItem("Clear All Mappings")) {
+      show_confirm_midi_clear_ = true;
+    }
+
+    if (ImGui::MenuItem("Save Config")) {
+      midi.save_config();
+    }
+
+    if (ImGui::MenuItem("Load Config")) {
+      midi.load_config();
+    }
+
+    ImGui::Separator();
+
+    // Show active mappings count
+    auto &mappings = midi.mappings();
+    ImGui::TextDisabled("%zu active mappings", mappings.size());
+
+    ImGui::EndPopup();
+  }
 }
 
 } // namespace Amplitron

--- a/src/gui/pedalboard/pedal_board_menu.cpp
+++ b/src/gui/pedalboard/pedal_board_menu.cpp
@@ -107,8 +107,13 @@ void PedalBoard::render_add_pedal_menu() {
         if (ImGui::MenuItem("+ Signal Splitter Node (1 In -> 2 Out)")) {
             history_.execute(std::make_unique<AddGraphNodeCommand>(engine_, "Splitter", NodeRoutingType::Splitter, nullptr, ImVec2(0, 0)));
         }
-        if (ImGui::MenuItem("+ Signal Mixer Node (2 In -> 1 Out)")) {
-            history_.execute(std::make_unique<AddGraphNodeCommand>(engine_, "Mixer", NodeRoutingType::Mixer, nullptr, ImVec2(0, 0)));
+        if (ImGui::BeginMenu("+ Signal Mixer Node (N-In -> 1 Out)")) {
+            for (int i = 2; i <= 8; ++i) {
+                if (ImGui::MenuItem((std::to_string(i) + " Inputs").c_str())) {
+                    history_.execute(std::make_unique<AddGraphNodeCommand>(engine_, "Mixer", NodeRoutingType::Mixer, nullptr, ImVec2(0, 0), i));
+                }
+            }
+            ImGui::EndMenu();
         }
 
         ImGui::EndPopup();

--- a/src/gui/pedalboard/pedal_widget.cpp
+++ b/src/gui/pedalboard/pedal_widget.cpp
@@ -164,6 +164,7 @@ void PedalWidget::render_standard_pedal(ImDrawList* dl, ImVec2 p0, ImVec2 p1, fl
 void PedalWidget::render_footswitch_and_extras(ImDrawList* dl, ImVec2 p0, ImVec2 p1, float pedal_width, float pedal_height, bool is_amp, bool enabled, bool& should_remove, float zoom) {
     (void)p1;
     (void)should_remove;
+    (void)dl;
     bool is_looper = !is_amp && (std::strcmp(effect_->name(), "Looper") == 0);
 
     // Footswitch (toggle on/off) — amps are always on, no footswitch

--- a/src/gui/pedalboard/pedal_widget_body.cpp
+++ b/src/gui/pedalboard/pedal_widget_body.cpp
@@ -7,6 +7,7 @@
 namespace Amplitron {
 
 void PedalWidget::render_amp_cabinet(ImDrawList* dl, ImVec2 p0, ImVec2 p1, float pedal_width, float pedal_height, float zoom) {
+    (void)pedal_height;
     ImU32 cab_body = IM_COL32(30, 22, 16, 255);
     ImU32 cab_border = IM_COL32(90, 70, 40, 255);
     ImU32 cab_grille = IM_COL32(18, 14, 10, 255);

--- a/src/midi/midi_manager_mapping.cpp
+++ b/src/midi/midi_manager_mapping.cpp
@@ -236,6 +236,22 @@ void MidiManager::apply_mapping(const MidiMapping& mapping, int cc_value,
             break;
         }
         case MidiTargetType::EffectParam: {
+            // Check if it's a Mixer Gain mapping
+            if (mapping.effect_name.find("Mixer_") == 0) {
+                int node_id = -1;
+                try { node_id = std::stoi(mapping.effect_name.substr(6)); } catch(...) {}
+                if (node_id != -1) {
+                    int pin_idx = -1;
+                    try { pin_idx = std::stoi(mapping.param_name.substr(5)); } catch(...) {}
+                    if (pin_idx != -1) {
+                        float gain = normalized * 2.0f;
+                        engine.graph().set_mixer_input_gain(node_id, pin_idx, gain);
+                        engine.push_mixer_gain_change(node_id, pin_idx, gain);
+                        break;
+                    }
+                }
+            }
+
             // Find the effect by name, then the param by name
             auto& effects = engine.effects();
             for (int i = 0; i < static_cast<int>(effects.size()); ++i) {

--- a/src/midi/midi_manager_mapping.cpp
+++ b/src/midi/midi_manager_mapping.cpp
@@ -242,7 +242,9 @@ void MidiManager::apply_mapping(const MidiMapping& mapping, int cc_value,
                 try { node_id = std::stoi(mapping.effect_name.substr(6)); } catch(...) {}
                 if (node_id != -1) {
                     int pin_idx = -1;
-                    try { pin_idx = std::stoi(mapping.param_name.substr(5)); } catch(...) {}
+                    if (mapping.param_name.find("Gain ") == 0) {
+                        try { pin_idx = std::stoi(mapping.param_name.substr(5)); } catch(...) {}
+                    }
                     if (pin_idx != -1) {
                         float gain = normalized * 2.0f;
                         engine.graph().set_mixer_input_gain(node_id, pin_idx, gain);

--- a/tests/integration/test_audio_graph.cpp
+++ b/tests/integration/test_audio_graph.cpp
@@ -1,7 +1,7 @@
 #include "audio/engine/audio_graph.h"
 #include "audio/engine/audio_graph_executor.h"
 #include "audio/effects/effect_factory.h"
-#include "preset_json.h"
+#include "presets/preset_json.h"
 #include "test_framework.h"
 #include <cmath>
 #include <map>
@@ -982,4 +982,72 @@ TEST(audio_graph_executor_implicit_input_output_paths) {
   for (float sample : output) {
     ASSERT_TRUE(std::isfinite(sample));
   }
+}
+
+// ============================================================================
+// N-Input Mixer Tests
+// ============================================================================
+
+TEST(audio_graph_mixer_n_inputs) {
+  AudioGraph graph;
+  int mixer = graph.add_node("Mixer", NodeRoutingType::Mixer);
+  auto* node = graph.find_node(mixer);
+  
+  // Default is 2 pins
+  ASSERT_TRUE(node->input_pin_ids.size() == 2);
+  
+  // Add a 3rd pin
+  ASSERT_TRUE(graph.add_input_pin(mixer));
+  ASSERT_TRUE(node->input_pin_ids.size() == 3);
+  
+  // Add a 4th pin
+  ASSERT_TRUE(graph.add_input_pin(mixer));
+  ASSERT_TRUE(node->input_pin_ids.size() == 4);
+  
+  // Test removing a pin
+  ASSERT_TRUE(graph.remove_input_pin(mixer));
+  ASSERT_TRUE(node->input_pin_ids.size() == 3);
+}
+
+TEST(audio_graph_mixer_gains) {
+  AudioGraph graph;
+  AudioGraphExecutor executor;
+  executor.prepare(48000, 128);
+
+  int p1 = graph.add_node("Splitter", NodeRoutingType::Splitter);
+  int mixer = graph.add_node("Mixer", NodeRoutingType::Mixer);
+  graph.add_input_pin(mixer); // 3 inputs
+  
+  graph.set_node_as_input(p1, true);
+  graph.set_node_as_output(mixer, true);
+
+  auto nodes = graph.get_nodes();
+  int path1 = graph.add_node("Path1", NodeRoutingType::StandardEffect);
+  int path2 = graph.add_node("Path2", NodeRoutingType::StandardEffect);
+  int path3 = graph.add_node("Path3", NodeRoutingType::StandardEffect);
+  
+  nodes = graph.get_nodes();
+  graph.add_link(nodes[0].output_pin_ids[0], nodes[2].input_pin_ids[0]); // p1[0] -> path1
+  graph.add_link(nodes[0].output_pin_ids[1], nodes[3].input_pin_ids[0]); // p1[1] -> path2
+  graph.set_node_as_input(path3, true);
+
+  nodes = graph.get_nodes();
+  graph.add_link(nodes[2].output_pin_ids[0], nodes[1].input_pin_ids[0]); // path1 -> mixer[0]
+  graph.add_link(nodes[3].output_pin_ids[0], nodes[1].input_pin_ids[1]); // path2 -> mixer[1]
+  graph.add_link(nodes[4].output_pin_ids[0], nodes[1].input_pin_ids[2]); // path3 -> mixer[2]
+
+  graph.set_mixer_input_gain(mixer, 0, 0.5f);
+  graph.set_mixer_input_gain(mixer, 1, 1.0f);
+  graph.set_mixer_input_gain(mixer, 2, 2.0f);
+
+  ASSERT_TRUE(graph.rebuild_topology());
+  executor.compile(graph);
+
+  std::vector<float> input_audio(64, 1.0f);
+  std::vector<float> output_audio(64, 0.0f);
+
+  executor.process(input_audio.data(), output_audio.data(), 64);
+  
+  // Output = 0.5 + 1.0 + 2.0 = 3.5
+  ASSERT_TRUE(std::abs(output_audio[0] - 3.5f) < 0.001f);
 }

--- a/tests/integration/test_audio_graph.cpp
+++ b/tests/integration/test_audio_graph.cpp
@@ -996,17 +996,35 @@ TEST(audio_graph_mixer_n_inputs) {
   // Default is 2 pins
   ASSERT_TRUE(node->input_pin_ids.size() == 2);
   
-  // Add a 3rd pin
-  ASSERT_TRUE(graph.add_input_pin(mixer));
-  ASSERT_TRUE(node->input_pin_ids.size() == 3);
+  // Create a Source node and connect it to the last pin
+  int source = graph.add_node("Source", NodeRoutingType::StandardEffect);
+  auto nodes = graph.get_nodes();
+  int source_out = -1;
+  int mixer_last_in = -1;
+  for (const auto& n : nodes) {
+      if (n.id == source) source_out = n.output_pin_ids.back();
+      if (n.id == mixer) mixer_last_in = n.input_pin_ids.back();
+  }
+  graph.add_link(source_out, mixer_last_in);
   
-  // Add a 4th pin
-  ASSERT_TRUE(graph.add_input_pin(mixer));
-  ASSERT_TRUE(node->input_pin_ids.size() == 4);
+  // Try to remove a connected pin -> should fail
+  ASSERT_FALSE(graph.remove_input_pin(mixer));
   
-  // Test removing a pin
-  ASSERT_TRUE(graph.remove_input_pin(mixer));
-  ASSERT_TRUE(node->input_pin_ids.size() == 3);
+  // Test max capacity (8 inputs)
+  while (graph.find_node(mixer)->input_pin_ids.size() < 8) {
+      ASSERT_TRUE(graph.add_input_pin(mixer));
+  }
+  
+  // 9th pin -> should fail
+  ASSERT_FALSE(graph.add_input_pin(mixer));
+  
+  // Remove down to 2 pins
+  while (graph.find_node(mixer)->input_pin_ids.size() > 2) {
+      ASSERT_TRUE(graph.remove_input_pin(mixer));
+  }
+  
+  // Removing below 2 pins -> should fail
+  ASSERT_FALSE(graph.remove_input_pin(mixer));
 }
 
 TEST(audio_graph_mixer_gains) {
@@ -1036,9 +1054,9 @@ TEST(audio_graph_mixer_gains) {
   graph.add_link(nodes[3].output_pin_ids[0], nodes[1].input_pin_ids[1]); // path2 -> mixer[1]
   graph.add_link(nodes[4].output_pin_ids[0], nodes[1].input_pin_ids[2]); // path3 -> mixer[2]
 
-  graph.set_mixer_input_gain(mixer, 0, 0.5f);
+  graph.set_mixer_input_gain(mixer, 0, -0.5f); // Should clamp to 0.0f
   graph.set_mixer_input_gain(mixer, 1, 1.0f);
-  graph.set_mixer_input_gain(mixer, 2, 2.0f);
+  graph.set_mixer_input_gain(mixer, 2, 3.0f);  // Should clamp to 2.0f
 
   ASSERT_TRUE(graph.rebuild_topology());
   executor.compile(graph);
@@ -1048,6 +1066,14 @@ TEST(audio_graph_mixer_gains) {
 
   executor.process(input_audio.data(), output_audio.data(), 64);
   
-  // Output = 0.5 + 1.0 + 2.0 = 3.5
-  ASSERT_TRUE(std::abs(output_audio[0] - 3.5f) < 0.001f);
+  // Output = 0.0 + 1.0 + 2.0 = 3.0
+  ASSERT_TRUE(std::abs(output_audio[0] - 3.0f) < 0.001f);
+  
+  // Test dynamic lock-free updates
+  executor.update_mixer_gain(mixer, 0, 0.25f);
+  std::fill(output_audio.begin(), output_audio.end(), 0.0f);
+  executor.process(input_audio.data(), output_audio.data(), 64);
+  
+  // Output = 0.25 + 1.0 + 2.0 = 3.25
+  ASSERT_TRUE(std::abs(output_audio[0] - 3.25f) < 0.001f);
 }

--- a/tests/integration/test_clipboard_preset.cpp
+++ b/tests/integration/test_clipboard_preset.cpp
@@ -1,54 +1,54 @@
+#include "presets/preset_json.h"
+#include "presets/preset_manager.h"
 #include "test_framework.h"
-#include "preset_json.h"
-#include "preset_manager.h"
-#include <string>
 #include <cmath>
+#include <string>
 
 using namespace Amplitron;
 
 // Test 1: Serialised JSON is non-empty for a valid preset
 TEST(clipboard_preset_serialise_returns_nonempty_string) {
-    PresetData pd;
-    pd.name = "Test Preset";
-    pd.description = "Test description";
-    pd.input_gain = 0.5f;
-    pd.output_gain = 0.5f;
-    std::string json = to_json_ext(pd);
-    ASSERT_FALSE(json.empty());
+  PresetData pd;
+  pd.name = "Test Preset";
+  pd.description = "Test description";
+  pd.input_gain = 0.5f;
+  pd.output_gain = 0.5f;
+  std::string json = to_json_ext(pd);
+  ASSERT_FALSE(json.empty());
 }
 
 // Test 2: Serialised JSON is valid JSON (contains { and })
 TEST(clipboard_preset_serialise_returns_valid_json) {
-    PresetData pd;
-    pd.name = "Test Preset";
-    std::string json = to_json_ext(pd);
-    ASSERT_NE(json.find('{'), std::string::npos);
-    ASSERT_NE(json.find('}'), std::string::npos);
+  PresetData pd;
+  pd.name = "Test Preset";
+  std::string json = to_json_ext(pd);
+  ASSERT_NE(json.find('{'), std::string::npos);
+  ASSERT_NE(json.find('}'), std::string::npos);
 }
 
 // Test 3: Round-trip — serialise then deserialise gives same preset
 TEST(clipboard_preset_roundtrip_restores_same_preset) {
-    PresetData pd;
-    pd.name = "Test Preset";
-    pd.description = "Test description";
-    pd.input_gain = 0.5f;
-    pd.output_gain = 0.5f;
-    
-    std::string json = to_json_ext(pd);
+  PresetData pd;
+  pd.name = "Test Preset";
+  pd.description = "Test description";
+  pd.input_gain = 0.5f;
+  pd.output_gain = 0.5f;
 
-    PresetData pd2;
-    bool loaded = from_json_ext(json, pd2);
-    ASSERT_TRUE(loaded);
-    
-    ASSERT_EQ(pd.name, pd2.name);
-    ASSERT_EQ(pd.description, pd2.description);
-    ASSERT_NEAR(pd.input_gain, pd2.input_gain, 0.001f);
-    ASSERT_NEAR(pd.output_gain, pd2.output_gain, 0.001f);
+  std::string json = to_json_ext(pd);
+
+  PresetData pd2;
+  bool loaded = from_json_ext(json, pd2);
+  ASSERT_TRUE(loaded);
+
+  ASSERT_EQ(pd.name, pd2.name);
+  ASSERT_EQ(pd.description, pd2.description);
+  ASSERT_NEAR(pd.input_gain, pd2.input_gain, 0.001f);
+  ASSERT_NEAR(pd.output_gain, pd2.output_gain, 0.001f);
 }
 
 // Test 4: Empty/invalid JSON does not crash
 TEST(clipboard_preset_load_invalid_json_returns_false) {
-    PresetData pd;
-    bool loaded = from_json_ext("not valid json {{{{", pd);
-    ASSERT_FALSE(loaded);
+  PresetData pd;
+  bool loaded = from_json_ext("not valid json {{{{", pd);
+  ASSERT_FALSE(loaded);
 }

--- a/tests/integration/test_json_serialization.cpp
+++ b/tests/integration/test_json_serialization.cpp
@@ -14,27 +14,27 @@
  * test_preset_signal_chain_dump
  */
 
-#include "test_framework.h"
-#include "preset_json.h"
-#include "preset_manager.h"
 #include "audio/engine/audio_engine.h"
+#include "presets/preset_json.h"
+#include "presets/preset_manager.h"
+#include "test_framework.h"
 #include <stdexcept>
 
-#include "audio/effects/noise_gate.h"
-#include "audio/effects/overdrive.h"
-#include "audio/effects/equalizer.h"
-#include "audio/effects/reverb.h"
 #include "audio/effects/compressor.h"
 #include "audio/effects/delay.h"
 #include "audio/effects/distortion.h" // Added for autosave test
+#include "audio/effects/equalizer.h"
+#include "audio/effects/noise_gate.h"
+#include "audio/effects/overdrive.h"
+#include "audio/effects/reverb.h"
 #include "midi/midi_manager.h"
 
-#include <nlohmann/json.hpp>
 #include <cstdio>
 #include <cstring>
-#include <iostream>
-#include <sstream>
 #include <filesystem>
+#include <iostream>
+#include <nlohmann/json.hpp>
+#include <sstream>
 
 using namespace Amplitron;
 
@@ -43,47 +43,47 @@ using namespace Amplitron;
 // -----------------------------------------------------------------------
 
 static PresetData make_test_preset() {
-    PresetData p;
-    p.name         = "Test Preset";
-    p.description  = "Created by test_json_serialization";
-    p.input_gain   = 0.75f;
-    p.output_gain  = 0.85f;
+  PresetData p;
+  p.name = "Test Preset";
+  p.description = "Created by test_json_serialization";
+  p.input_gain = 0.75f;
+  p.output_gain = 0.85f;
 
-    {
-        PresetData::EffectData fx;
-        fx.type    = "Noise Gate";
-        fx.enabled = true;
-        fx.mix     = 1.0f;
-        fx.params  = {{"Threshold", -40.0f}, {"Attack", 0.5f}, {"Release", 50.0f}};
-        p.effects.push_back(fx);
-    }
-    {
-        PresetData::EffectData fx;
-        fx.type    = "Overdrive";
-        fx.enabled = false;
-        fx.mix     = 0.8f;
-        fx.params  = {{"Drive", 2.5f}, {"Tone", 0.6f}, {"Level", 0.7f}};
-        p.effects.push_back(fx);
-    }
-    {
-        PresetData::EffectData fx;
-        fx.type     = "Cabinet";
-        fx.enabled  = true;
-        fx.mix      = 1.0f;
-        fx.metadata = {{"ir_path", "/some/path/cabinet.wav"}};
-        p.effects.push_back(fx);
-    }
+  {
+    PresetData::EffectData fx;
+    fx.type = "Noise Gate";
+    fx.enabled = true;
+    fx.mix = 1.0f;
+    fx.params = {{"Threshold", -40.0f}, {"Attack", 0.5f}, {"Release", 50.0f}};
+    p.effects.push_back(fx);
+  }
+  {
+    PresetData::EffectData fx;
+    fx.type = "Overdrive";
+    fx.enabled = false;
+    fx.mix = 0.8f;
+    fx.params = {{"Drive", 2.5f}, {"Tone", 0.6f}, {"Level", 0.7f}};
+    p.effects.push_back(fx);
+  }
+  {
+    PresetData::EffectData fx;
+    fx.type = "Cabinet";
+    fx.enabled = true;
+    fx.mix = 1.0f;
+    fx.metadata = {{"ir_path", "/some/path/cabinet.wav"}};
+    p.effects.push_back(fx);
+  }
 
-    MidiMapping m;
-    m.cc_number    = 74;
-    m.midi_channel = 0;
-    m.target_type  = MidiTargetType::EffectParam;
-    m.mode         = MidiMappingMode::Continuous;
-    m.effect_name  = "Overdrive";
-    m.param_name   = "Drive";
-    p.midi_mappings.push_back(m);
+  MidiMapping m;
+  m.cc_number = 74;
+  m.midi_channel = 0;
+  m.target_type = MidiTargetType::EffectParam;
+  m.mode = MidiMappingMode::Continuous;
+  m.effect_name = "Overdrive";
+  m.param_name = "Drive";
+  p.midi_mappings.push_back(m);
 
-    return p;
+  return p;
 }
 
 // -----------------------------------------------------------------------
@@ -91,55 +91,55 @@ static PresetData make_test_preset() {
 // -----------------------------------------------------------------------
 
 TEST(json_effect_data_to_json_contains_expected_keys) {
-    PresetData::EffectData fx;
-    fx.type    = "Reverb";
-    fx.enabled = true;
-    fx.mix     = 0.5f;
-    fx.params  = {{"Decay", 0.8f}, {"Damp", 0.3f}, {"Level", 0.4f}};
+  PresetData::EffectData fx;
+  fx.type = "Reverb";
+  fx.enabled = true;
+  fx.mix = 0.5f;
+  fx.params = {{"Decay", 0.8f}, {"Damp", 0.3f}, {"Level", 0.4f}};
 
-    nlohmann::json j;
-    Amplitron::to_json(j, fx);
+  nlohmann::json j;
+  Amplitron::to_json(j, fx);
 
-    ASSERT_TRUE(j.contains("type"));
-    ASSERT_TRUE(j.contains("enabled"));
-    ASSERT_TRUE(j.contains("mix"));
-    ASSERT_TRUE(j.contains("params"));
-    ASSERT_EQ(j["type"].get<std::string>(), std::string("Reverb"));
-    ASSERT_EQ(j["enabled"].get<bool>(), true);
-    ASSERT_TRUE(j["params"].contains("Decay"));
-    ASSERT_NEAR(j["params"]["Decay"].get<float>(), 0.8f, 0.001f);
+  ASSERT_TRUE(j.contains("type"));
+  ASSERT_TRUE(j.contains("enabled"));
+  ASSERT_TRUE(j.contains("mix"));
+  ASSERT_TRUE(j.contains("params"));
+  ASSERT_EQ(j["type"].get<std::string>(), std::string("Reverb"));
+  ASSERT_EQ(j["enabled"].get<bool>(), true);
+  ASSERT_TRUE(j["params"].contains("Decay"));
+  ASSERT_NEAR(j["params"]["Decay"].get<float>(), 0.8f, 0.001f);
 }
 
 TEST(json_effect_data_roundtrip) {
-    PresetData::EffectData original;
-    original.type    = "Equalizer";
-    original.enabled = true;
-    original.mix     = 0.9f;
-    original.params  = {{"Bass", 3.0f}, {"Mid", -2.0f}, {"Treble", 1.5f}};
-    original.metadata = {{"custom_key", "custom_value"}};
+  PresetData::EffectData original;
+  original.type = "Equalizer";
+  original.enabled = true;
+  original.mix = 0.9f;
+  original.params = {{"Bass", 3.0f}, {"Mid", -2.0f}, {"Treble", 1.5f}};
+  original.metadata = {{"custom_key", "custom_value"}};
 
-    // Serialise
-    nlohmann::json j;
-    Amplitron::to_json(j, original);
+  // Serialise
+  nlohmann::json j;
+  Amplitron::to_json(j, original);
 
-    // Deserialise
-    PresetData::EffectData restored;
-    Amplitron::from_json(j, restored);
+  // Deserialise
+  PresetData::EffectData restored;
+  Amplitron::from_json(j, restored);
 
-    ASSERT_EQ(restored.type,    original.type);
-    ASSERT_EQ(restored.enabled, original.enabled);
-    ASSERT_NEAR(restored.mix,   original.mix, 0.001f);
-    ASSERT_EQ(restored.params.size(), original.params.size());
+  ASSERT_EQ(restored.type, original.type);
+  ASSERT_EQ(restored.enabled, original.enabled);
+  ASSERT_NEAR(restored.mix, original.mix, 0.001f);
+  ASSERT_EQ(restored.params.size(), original.params.size());
 
-    // Verify each parameter
-    for (size_t i = 0; i < original.params.size(); ++i) {
-        ASSERT_EQ(restored.params[i].first, original.params[i].first);
-        ASSERT_NEAR(restored.params[i].second, original.params[i].second, 0.001f);
-    }
+  // Verify each parameter
+  for (size_t i = 0; i < original.params.size(); ++i) {
+    ASSERT_EQ(restored.params[i].first, original.params[i].first);
+    ASSERT_NEAR(restored.params[i].second, original.params[i].second, 0.001f);
+  }
 
-    // Verify metadata
-    ASSERT_EQ(restored.metadata.count("custom_key"), 1u);
-    ASSERT_EQ(restored.metadata.at("custom_key"), std::string("custom_value"));
+  // Verify metadata
+  ASSERT_EQ(restored.metadata.count("custom_key"), 1u);
+  ASSERT_EQ(restored.metadata.at("custom_key"), std::string("custom_value"));
 }
 
 // -----------------------------------------------------------------------
@@ -147,88 +147,89 @@ TEST(json_effect_data_roundtrip) {
 // -----------------------------------------------------------------------
 
 TEST(json_preset_roundtrip_via_string) {
-    PresetData original = make_test_preset();
+  PresetData original = make_test_preset();
 
-    // Serialise to JSON string
-    std::string json_str = to_json_ext(original);
+  // Serialise to JSON string
+  std::string json_str = to_json_ext(original);
 
-    // Validate it is parseable as valid JSON
-    ASSERT_TRUE(!json_str.empty());
-    ASSERT_TRUE(nlohmann::json::accept(json_str));
+  // Validate it is parseable as valid JSON
+  ASSERT_TRUE(!json_str.empty());
+  ASSERT_TRUE(nlohmann::json::accept(json_str));
 
-    // Deserialise back
-    PresetData restored;
-    bool ok = from_json_ext(json_str, restored);
-    ASSERT_TRUE(ok);
+  // Deserialise back
+  PresetData restored;
+  bool ok = from_json_ext(json_str, restored);
+  ASSERT_TRUE(ok);
 
-    // Top-level fields
-    ASSERT_EQ(restored.name,        original.name);
-    ASSERT_EQ(restored.description, original.description);
-    ASSERT_NEAR(restored.input_gain,  original.input_gain,  0.001f);
-    ASSERT_NEAR(restored.output_gain, original.output_gain, 0.001f);
+  // Top-level fields
+  ASSERT_EQ(restored.name, original.name);
+  ASSERT_EQ(restored.description, original.description);
+  ASSERT_NEAR(restored.input_gain, original.input_gain, 0.001f);
+  ASSERT_NEAR(restored.output_gain, original.output_gain, 0.001f);
 
-    // Effect chain length
-    ASSERT_EQ(restored.effects.size(), original.effects.size());
+  // Effect chain length
+  ASSERT_EQ(restored.effects.size(), original.effects.size());
 
-    // First effect: Noise Gate
-    ASSERT_EQ(restored.effects[0].type,    std::string("Noise Gate"));
-    ASSERT_EQ(restored.effects[0].enabled, true);
-    ASSERT_NEAR(restored.effects[0].mix,   1.0f, 0.001f);
-    ASSERT_EQ(restored.effects[0].params.size(), 3u);
-    ASSERT_NEAR(restored.effects[0].params[0].second, -40.0f, 0.001f);
+  // First effect: Noise Gate
+  ASSERT_EQ(restored.effects[0].type, std::string("Noise Gate"));
+  ASSERT_EQ(restored.effects[0].enabled, true);
+  ASSERT_NEAR(restored.effects[0].mix, 1.0f, 0.001f);
+  ASSERT_EQ(restored.effects[0].params.size(), 3u);
+  ASSERT_NEAR(restored.effects[0].params[0].second, -40.0f, 0.001f);
 
-    // Second effect: Overdrive (disabled)
-    ASSERT_EQ(restored.effects[1].type,    std::string("Overdrive"));
-    ASSERT_EQ(restored.effects[1].enabled, false);
-    ASSERT_NEAR(restored.effects[1].mix,   0.8f, 0.001f);
+  // Second effect: Overdrive (disabled)
+  ASSERT_EQ(restored.effects[1].type, std::string("Overdrive"));
+  ASSERT_EQ(restored.effects[1].enabled, false);
+  ASSERT_NEAR(restored.effects[1].mix, 0.8f, 0.001f);
 
-    // Third effect: Cabinet with IR metadata
-    ASSERT_EQ(restored.effects[2].type,    std::string("Cabinet"));
-    ASSERT_EQ(restored.effects[2].metadata.count("ir_path"), 1u);
-    ASSERT_EQ(restored.effects[2].metadata.at("ir_path"),
-              std::string("/some/path/cabinet.wav"));
+  // Third effect: Cabinet with IR metadata
+  ASSERT_EQ(restored.effects[2].type, std::string("Cabinet"));
+  ASSERT_EQ(restored.effects[2].metadata.count("ir_path"), 1u);
+  ASSERT_EQ(restored.effects[2].metadata.at("ir_path"),
+            std::string("/some/path/cabinet.wav"));
 
-    // MIDI mappings
-    ASSERT_EQ(restored.midi_mappings.size(), 1u);
-    ASSERT_EQ(restored.midi_mappings[0].cc_number,  74);
-    ASSERT_EQ(restored.midi_mappings[0].effect_name, std::string("Overdrive"));
-    ASSERT_EQ(restored.midi_mappings[0].param_name,  std::string("Drive"));
+  // MIDI mappings
+  ASSERT_EQ(restored.midi_mappings.size(), 1u);
+  ASSERT_EQ(restored.midi_mappings[0].cc_number, 74);
+  ASSERT_EQ(restored.midi_mappings[0].effect_name, std::string("Overdrive"));
+  ASSERT_EQ(restored.midi_mappings[0].param_name, std::string("Drive"));
 }
 
 TEST(json_roundtrip_via_file) {
-    PresetData original = make_test_preset();
-    original.name = "FileRoundtripTest";
+  PresetData original = make_test_preset();
+  original.name = "FileRoundtripTest";
 
-    // Keep this PresetManager load test deterministic. IR metadata
-    // serialization is already covered in json_preset_roundtrip_via_string.
-    original.effects.resize(2);
+  // Keep this PresetManager load test deterministic. IR metadata
+  // serialization is already covered in json_preset_roundtrip_via_string.
+  original.effects.resize(2);
 
-    std::string path = "presets/test_nlohmann_roundtrip.json";
-    std::filesystem::create_directories("presets");
+  std::string path = "presets/test_nlohmann_roundtrip.json";
+  std::filesystem::create_directories("presets");
 
-    // Save via PresetManager (which calls to_json_ext internally)
-    bool saved = PresetManager::save_preset_data(path, original);
-    ASSERT_TRUE(saved);
+  // Save via PresetManager (which calls to_json_ext internally)
+  bool saved = PresetManager::save_preset_data(path, original);
+  ASSERT_TRUE(saved);
 
-    // Load via PresetManager (which calls from_json_ext internally)
-    AudioEngine engine;
-    engine.initialize();
-    bool loaded = PresetManager::load_preset(path, engine);
-    ASSERT_TRUE(loaded);
+  // Load via PresetManager (which calls from_json_ext internally)
+  AudioEngine engine;
+  engine.initialize();
+  bool loaded = PresetManager::load_preset(path, engine);
+  ASSERT_TRUE(loaded);
 
-    ASSERT_EQ(static_cast<int>(engine.effects().size()), 2); // IR effect skipped (no real IR)
-    ASSERT_NEAR(engine.get_input_gain(),  0.75f, 0.01f);
-    ASSERT_NEAR(engine.get_output_gain(), 0.85f, 0.01f);
+  ASSERT_EQ(static_cast<int>(engine.effects().size()),
+            2); // IR effect skipped (no real IR)
+  ASSERT_NEAR(engine.get_input_gain(), 0.75f, 0.01f);
+  ASSERT_NEAR(engine.get_output_gain(), 0.85f, 0.01f);
 
-    // Verify the legacy linear preset correctly wired the AudioGraph!
-    const auto& graph = engine.graph();
-    ASSERT_EQ(graph.get_nodes().size(), 3u); // Input -> Noise Gate -> Overdrive
-    ASSERT_EQ(graph.get_links().size(), 2u);
-    ASSERT_TRUE(graph.get_nodes().front().is_graph_input);
-    ASSERT_TRUE(graph.get_nodes().back().is_graph_output);
+  // Verify the legacy linear preset correctly wired the AudioGraph!
+  const auto &graph = engine.graph();
+  ASSERT_EQ(graph.get_nodes().size(), 3u); // Input -> Noise Gate -> Overdrive
+  ASSERT_EQ(graph.get_links().size(), 2u);
+  ASSERT_TRUE(graph.get_nodes().front().is_graph_input);
+  ASSERT_TRUE(graph.get_nodes().back().is_graph_output);
 
-    std::remove(path.c_str());
-    engine.shutdown();
+  std::remove(path.c_str());
+  engine.shutdown();
 }
 
 // -----------------------------------------------------------------------
@@ -236,131 +237,132 @@ TEST(json_roundtrip_via_file) {
 // -----------------------------------------------------------------------
 
 TEST(json_preset_signal_chain_dump) {
-    // Build the default signal chain that Amplitron starts with
-    AudioEngine engine;
-    engine.initialize();
+  // Build the default signal chain that Amplitron starts with
+  AudioEngine engine;
+  engine.initialize();
 
-    engine.add_effect(std::make_shared<NoiseGate>());
-    engine.add_effect(std::make_shared<Compressor>());
-    engine.add_effect(std::make_shared<Overdrive>());
-    engine.add_effect(std::make_shared<Equalizer>());
-    engine.add_effect(std::make_shared<Delay>());
-    engine.add_effect(std::make_shared<Reverb>());
+  engine.add_effect(std::make_shared<NoiseGate>());
+  engine.add_effect(std::make_shared<Compressor>());
+  engine.add_effect(std::make_shared<Overdrive>());
+  engine.add_effect(std::make_shared<Equalizer>());
+  engine.add_effect(std::make_shared<Delay>());
+  engine.add_effect(std::make_shared<Reverb>());
 
-    engine.set_input_gain(0.7f);
-    engine.set_output_gain(0.8f);
+  engine.set_input_gain(0.7f);
+  engine.set_output_gain(0.8f);
 
-    // Collect state into a PresetData (same logic as PresetManager::save_preset)
-    PresetData state;
-    state.name        = "Default Signal Chain";
-    state.description = "Proof-of-concept dump for issue #96";
-    state.input_gain  = engine.get_input_gain();
-    state.output_gain = engine.get_output_gain();
-    for (auto& fx : engine.effects()) {
-        PresetData::EffectData fd;
-        fd.type    = fx->name();
-        fd.enabled = fx->is_enabled();
-        fd.mix     = fx->get_mix();
-        for (auto& p : fx->params()) {
-            fd.params.push_back({p.name, p.value});
-        }
-        state.effects.push_back(fd);
+  // Collect state into a PresetData (same logic as PresetManager::save_preset)
+  PresetData state;
+  state.name = "Default Signal Chain";
+  state.description = "Proof-of-concept dump for issue #96";
+  state.input_gain = engine.get_input_gain();
+  state.output_gain = engine.get_output_gain();
+  for (auto &fx : engine.effects()) {
+    PresetData::EffectData fd;
+    fd.type = fx->name();
+    fd.enabled = fx->is_enabled();
+    fd.mix = fx->get_mix();
+    for (auto &p : fx->params()) {
+      fd.params.push_back({p.name, p.value});
     }
+    state.effects.push_back(fd);
+  }
 
-    // Dump to JSON string and print to console (proves library is working)
-    std::string json_str = to_json_ext(state);
-    std::cout << "\n[test_json_serialization] Default signal chain JSON:\n"
-              << json_str << std::endl;
+  // Dump to JSON string and print to console (proves library is working)
+  std::string json_str = to_json_ext(state);
+  std::cout << "\n[test_json_serialization] Default signal chain JSON:\n"
+            << json_str << std::endl;
 
-    // Structural assertions
-    ASSERT_FALSE(json_str.empty());
+  // Structural assertions
+  ASSERT_FALSE(json_str.empty());
 
-    nlohmann::json j = nlohmann::json::parse(json_str);
-    ASSERT_TRUE(j.contains("format_version"));
-    ASSERT_TRUE(j.contains("name"));
-    ASSERT_TRUE(j.contains("effects"));
-    ASSERT_EQ(j["effects"].size(), 6u);
+  nlohmann::json j = nlohmann::json::parse(json_str);
+  ASSERT_TRUE(j.contains("format_version"));
+  ASSERT_TRUE(j.contains("name"));
+  ASSERT_TRUE(j.contains("effects"));
+  ASSERT_EQ(j["effects"].size(), 6u);
 
-    // Every effect block must have type, enabled, mix, params
-    for (auto& jfx : j["effects"]) {
-        ASSERT_TRUE(jfx.contains("type"));
-        ASSERT_TRUE(jfx.contains("enabled"));
-        ASSERT_TRUE(jfx.contains("mix"));
-        ASSERT_TRUE(jfx.contains("params"));
+  // Every effect block must have type, enabled, mix, params
+  for (auto &jfx : j["effects"]) {
+    ASSERT_TRUE(jfx.contains("type"));
+    ASSERT_TRUE(jfx.contains("enabled"));
+    ASSERT_TRUE(jfx.contains("mix"));
+    ASSERT_TRUE(jfx.contains("params"));
+  }
+
+  // Round-trip: parse back and verify no data loss
+  PresetData restored;
+  bool ok = from_json_ext(json_str, restored);
+  ASSERT_TRUE(ok);
+  ASSERT_EQ(restored.effects.size(), state.effects.size());
+  for (size_t i = 0; i < state.effects.size(); ++i) {
+    ASSERT_EQ(restored.effects[i].type, state.effects[i].type);
+    ASSERT_EQ(restored.effects[i].enabled, state.effects[i].enabled);
+    ASSERT_NEAR(restored.effects[i].mix, state.effects[i].mix, 0.001f);
+    ASSERT_EQ(restored.effects[i].params.size(),
+              state.effects[i].params.size());
+    for (size_t p = 0; p < state.effects[i].params.size(); ++p) {
+      ASSERT_EQ(restored.effects[i].params[p].first,
+                state.effects[i].params[p].first);
+      ASSERT_NEAR(restored.effects[i].params[p].second,
+                  state.effects[i].params[p].second, 0.001f);
     }
+  }
 
-    // Round-trip: parse back and verify no data loss
-    PresetData restored;
-    bool ok = from_json_ext(json_str, restored);
-    ASSERT_TRUE(ok);
-    ASSERT_EQ(restored.effects.size(), state.effects.size());
-    for (size_t i = 0; i < state.effects.size(); ++i) {
-        ASSERT_EQ(restored.effects[i].type,    state.effects[i].type);
-        ASSERT_EQ(restored.effects[i].enabled, state.effects[i].enabled);
-        ASSERT_NEAR(restored.effects[i].mix,   state.effects[i].mix, 0.001f);
-        ASSERT_EQ(restored.effects[i].params.size(),
-                  state.effects[i].params.size());
-        for (size_t p = 0; p < state.effects[i].params.size(); ++p) {
-            ASSERT_EQ(restored.effects[i].params[p].first,
-                      state.effects[i].params[p].first);
-            ASSERT_NEAR(restored.effects[i].params[p].second,
-                        state.effects[i].params[p].second, 0.001f);
-        }
-    }
-
-    engine.shutdown();
+  engine.shutdown();
 }
 
 TEST(json_invalid_json_returns_false) {
-    PresetData preset;
-    bool ok = from_json_ext("{ this is not valid json !!!", preset);
-    ASSERT_FALSE(ok);
+  PresetData preset;
+  bool ok = from_json_ext("{ this is not valid json !!!", preset);
+  ASSERT_FALSE(ok);
 }
 
 TEST(json_empty_effects_list_roundtrip) {
-    PresetData original;
-    original.name        = "Empty Chain";
-    original.input_gain  = 0.5f;
-    original.output_gain = 0.5f;
-    // No effects, no midi mappings
+  PresetData original;
+  original.name = "Empty Chain";
+  original.input_gain = 0.5f;
+  original.output_gain = 0.5f;
+  // No effects, no midi mappings
 
-    std::string json_str = to_json_ext(original);
-    PresetData restored;
-    bool ok = from_json_ext(json_str, restored);
-    ASSERT_TRUE(ok);
-    ASSERT_EQ(restored.name, std::string("Empty Chain"));
-    ASSERT_EQ(restored.effects.size(), 0u);
-    ASSERT_EQ(restored.midi_mappings.size(), 0u);
+  std::string json_str = to_json_ext(original);
+  PresetData restored;
+  bool ok = from_json_ext(json_str, restored);
+  ASSERT_TRUE(ok);
+  ASSERT_EQ(restored.name, std::string("Empty Chain"));
+  ASSERT_EQ(restored.effects.size(), 0u);
+  ASSERT_EQ(restored.midi_mappings.size(), 0u);
 }
 
 TEST(json_can_load_existing_factory_presets) {
-    // Verify the new parser is backward-compatible with the existing preset files
-    const std::vector<std::string> factory_presets = {
-        "presets/05_Phase_Shift_Lead.json",
-        "presets/06_Jet_Flanger.json",
-    };
+  // Verify the new parser is backward-compatible with the existing preset files
+  const std::vector<std::string> factory_presets = {
+      "presets/05_Phase_Shift_Lead.json",
+      "presets/06_Jet_Flanger.json",
+  };
 
-    int loaded_count = 0;
+  int loaded_count = 0;
 
-    for (const auto& path : factory_presets) {
-        std::ifstream f(path);
-        if (!f.is_open()) continue; // Skip if not found in test environment
+  for (const auto &path : factory_presets) {
+    std::ifstream f(path);
+    if (!f.is_open())
+      continue; // Skip if not found in test environment
 
-        std::string content((std::istreambuf_iterator<char>(f)),
-                             std::istreambuf_iterator<char>());
-        f.close();
+    std::string content((std::istreambuf_iterator<char>(f)),
+                        std::istreambuf_iterator<char>());
+    f.close();
 
-        PresetData preset;
-        bool ok = from_json_ext(content, preset);
-        ASSERT_TRUE(ok);
-        ASSERT_FALSE(preset.name.empty());
-        ASSERT_FALSE(preset.effects.empty());
-        ++loaded_count;
-    }
+    PresetData preset;
+    bool ok = from_json_ext(content, preset);
+    ASSERT_TRUE(ok);
+    ASSERT_FALSE(preset.name.empty());
+    ASSERT_FALSE(preset.effects.empty());
+    ++loaded_count;
+  }
 
-    // FIX: prevent vacuous pass — if all files are missing the loop skips
-    // everything and the test proves nothing (CodeRabbit issue #4).
-    ASSERT_GT(loaded_count, 0);
+  // FIX: prevent vacuous pass — if all files are missing the loop skips
+  // everything and the test proves nothing (CodeRabbit issue #4).
+  ASSERT_GT(loaded_count, 0);
 }
 
 // -----------------------------------------------------------------------
@@ -368,129 +370,126 @@ TEST(json_can_load_existing_factory_presets) {
 // -----------------------------------------------------------------------
 
 TEST(json_audio_engine_autosave_roundtrip) {
-    AudioEngine engine;
-    engine.initialize();
-    
-    // 1. Setup a specific chain state
-    auto distortion = std::make_shared<Distortion>();
-    distortion->set_enabled(true);
-    distortion->set_mix(0.85f);
-    engine.add_effect(distortion);
+  AudioEngine engine;
+  engine.initialize();
 
-    auto reverb = std::make_shared<Reverb>();
-    reverb->set_enabled(false);
-    reverb->set_mix(0.2f);
-    engine.add_effect(reverb);
+  // 1. Setup a specific chain state
+  auto distortion = std::make_shared<Distortion>();
+  distortion->set_enabled(true);
+  distortion->set_mix(0.85f);
+  engine.add_effect(distortion);
 
-    // 2. Serialize the state to JSON using the new Autosave hooks
-    nlohmann::json saved_state = engine.serialize();
+  auto reverb = std::make_shared<Reverb>();
+  reverb->set_enabled(false);
+  reverb->set_mix(0.2f);
+  engine.add_effect(reverb);
 
-    // 3. Deliberately ruin the current state (simulate user messing it up before crash)
-    distortion->set_enabled(false);
-    distortion->set_mix(0.0f);
-    reverb->set_enabled(true);
-    reverb->set_mix(1.0f);
+  // 2. Serialize the state to JSON using the new Autosave hooks
+  nlohmann::json saved_state = engine.serialize();
 
-    // 4. Trigger Crash Recovery (Deserialize)
-    engine.deserialize(saved_state);
+  // 3. Deliberately ruin the current state (simulate user messing it up before
+  // crash)
+  distortion->set_enabled(false);
+  distortion->set_mix(0.0f);
+  reverb->set_enabled(true);
+  reverb->set_mix(1.0f);
 
-    // 5. Assert that everything was restored perfectly
-    ASSERT_TRUE(distortion->is_enabled());
-    ASSERT_NEAR(distortion->get_mix(), 0.85f, 0.001f); 
+  // 4. Trigger Crash Recovery (Deserialize)
+  engine.deserialize(saved_state);
 
-    ASSERT_FALSE(reverb->is_enabled());
-    ASSERT_NEAR(reverb->get_mix(), 0.2f, 0.001f);
-    
-    engine.shutdown();
+  // 5. Assert that everything was restored perfectly
+  ASSERT_TRUE(distortion->is_enabled());
+  ASSERT_NEAR(distortion->get_mix(), 0.85f, 0.001f);
+
+  ASSERT_FALSE(reverb->is_enabled());
+  ASSERT_NEAR(reverb->get_mix(), 0.2f, 0.001f);
+
+  engine.shutdown();
 }
 
 TEST(json_graph_node_and_link_roundtrip) {
-    PresetData preset;
-    preset.routing = "graph";
-    
-    PresetData::NodeData n;
-    n.id = "n1";
-    n.type = "Overdrive";
-    n.enabled = true;
-    n.mix = 0.5f;
-    n.num_inputs = 2;
-    n.x = 10.0f;
-    n.y = 20.0f;
-    n.params.push_back({"Drive", 1.0f});
-    n.metadata["test"] = "meta";
-    preset.nodes.push_back(n);
+  PresetData preset;
+  preset.routing = "graph";
 
-    PresetData::LinkData l;
-    l.src_pin = "p1";
-    l.dst_pin = "p2";
-    preset.links.push_back(l);
+  PresetData::NodeData n;
+  n.id = "n1";
+  n.type = "Overdrive";
+  n.enabled = true;
+  n.mix = 0.5f;
+  n.num_inputs = 2;
+  n.x = 10.0f;
+  n.y = 20.0f;
+  n.params.push_back({"Drive", 1.0f});
+  n.metadata["test"] = "meta";
+  preset.nodes.push_back(n);
 
-    std::string json_str = to_json_ext(preset);
-    
-    PresetData restored;
-    bool ok = from_json_ext(json_str, restored);
-    ASSERT_TRUE(ok);
-    
-    ASSERT_EQ(restored.nodes.size(), 1u);
-    ASSERT_EQ(restored.nodes[0].id, "n1");
-    ASSERT_EQ(restored.nodes[0].type, "Overdrive");
-    ASSERT_TRUE(restored.nodes[0].enabled);
-    ASSERT_EQ(restored.nodes[0].mix, 0.5f);
-    ASSERT_EQ(restored.nodes[0].num_inputs, 2);
-    ASSERT_EQ(restored.nodes[0].x, 10.0f);
-    ASSERT_EQ(restored.nodes[0].y, 20.0f);
-    ASSERT_EQ(restored.nodes[0].params.size(), 1u);
-    ASSERT_EQ(restored.nodes[0].metadata["test"], "meta");
+  PresetData::LinkData l;
+  l.src_pin = "p1";
+  l.dst_pin = "p2";
+  preset.links.push_back(l);
 
-    ASSERT_EQ(restored.links.size(), 1u);
-    ASSERT_EQ(restored.links[0].src_pin, "p1");
-    ASSERT_EQ(restored.links[0].dst_pin, "p2");
+  std::string json_str = to_json_ext(preset);
+
+  PresetData restored;
+  bool ok = from_json_ext(json_str, restored);
+  ASSERT_TRUE(ok);
+
+  ASSERT_EQ(restored.nodes.size(), 1u);
+  ASSERT_EQ(restored.nodes[0].id, "n1");
+  ASSERT_EQ(restored.nodes[0].type, "Overdrive");
+  ASSERT_TRUE(restored.nodes[0].enabled);
+  ASSERT_EQ(restored.nodes[0].mix, 0.5f);
+  ASSERT_EQ(restored.nodes[0].num_inputs, 2);
+  ASSERT_EQ(restored.nodes[0].x, 10.0f);
+  ASSERT_EQ(restored.nodes[0].y, 20.0f);
+  ASSERT_EQ(restored.nodes[0].params.size(), 1u);
+  ASSERT_EQ(restored.nodes[0].metadata["test"], "meta");
+
+  ASSERT_EQ(restored.links.size(), 1u);
+  ASSERT_EQ(restored.links[0].src_pin, "p1");
+  ASSERT_EQ(restored.links[0].dst_pin, "p2");
 }
 
 TEST(json_from_json_ext_exceptions) {
-    PresetData p;
-    // Missing nodes
-    bool ok1 = from_json_ext(R"({"routing": "graph", "links": []})", p);
-    ASSERT_FALSE(ok1);
-    
-    // Missing links
-    bool ok2 = from_json_ext(R"({"routing": "graph", "nodes": []})", p);
-    ASSERT_FALSE(ok2);
+  PresetData p;
+  // Missing nodes
+  bool ok1 = from_json_ext(R"({"routing": "graph", "links": []})", p);
+  ASSERT_FALSE(ok1);
+
+  // Missing links
+  bool ok2 = from_json_ext(R"({"routing": "graph", "nodes": []})", p);
+  ASSERT_FALSE(ok2);
 }
 
 TEST(json_from_json_exceptions) {
-    nlohmann::json j1 = {
-        {"routing", "graph"},
-        {"links", nlohmann::json::array()}
-    };
-    PresetData p1;
-    bool caught1 = false;
-    try {
-        from_json(j1, p1);
-    } catch(const std::invalid_argument&) {
-        caught1 = true;
-    }
-    ASSERT_TRUE(caught1);
+  nlohmann::json j1 = {{"routing", "graph"},
+                       {"links", nlohmann::json::array()}};
+  PresetData p1;
+  bool caught1 = false;
+  try {
+    from_json(j1, p1);
+  } catch (const std::invalid_argument &) {
+    caught1 = true;
+  }
+  ASSERT_TRUE(caught1);
 
-    nlohmann::json j2 = {
-        {"routing", "graph"},
-        {"nodes", nlohmann::json::array()}
-    };
-    PresetData p2;
-    bool caught2 = false;
-    try {
-        from_json(j2, p2);
-    } catch(const std::invalid_argument&) {
-        caught2 = true;
-    }
-    ASSERT_TRUE(caught2);
+  nlohmann::json j2 = {{"routing", "graph"},
+                       {"nodes", nlohmann::json::array()}};
+  PresetData p2;
+  bool caught2 = false;
+  try {
+    from_json(j2, p2);
+  } catch (const std::invalid_argument &) {
+    caught2 = true;
+  }
+  ASSERT_TRUE(caught2);
 }
 
 TEST(json_from_ordered_json_missing_fields) {
-    // Actually the namespace requires us to use from_json_ext because ordered json hook is internal.
-    // So we just parse from string
-    PresetData p;
-    bool ok = from_json_ext(R"({
+  // Actually the namespace requires us to use from_json_ext because ordered
+  // json hook is internal. So we just parse from string
+  PresetData p;
+  bool ok = from_json_ext(R"({
         "format_version": 2,
         "routing": "graph",
         "name": "Missing Fields",
@@ -498,16 +497,17 @@ TEST(json_from_ordered_json_missing_fields) {
             { "id": "n1", "type": "test" }
         ],
         "links": []
-    })", p);
-    ASSERT_TRUE(ok);
-    ASSERT_EQ(p.nodes.size(), 1u);
-    ASSERT_EQ(p.nodes[0].id, "n1");
-    ASSERT_TRUE(p.nodes[0].enabled); // Default true
-    ASSERT_EQ(p.nodes[0].mix, 1.0f);
+    })",
+                          p);
+  ASSERT_TRUE(ok);
+  ASSERT_EQ(p.nodes.size(), 1u);
+  ASSERT_EQ(p.nodes[0].id, "n1");
+  ASSERT_TRUE(p.nodes[0].enabled); // Default true
+  ASSERT_EQ(p.nodes[0].mix, 1.0f);
 }
 
 TEST(json_from_json_missing_fields) {
-    nlohmann::json j = nlohmann::json::parse(R"({
+  nlohmann::json j = nlohmann::json::parse(R"({
         "format_version": 2,
         "routing": "graph",
         "name": "Missing Fields",
@@ -516,16 +516,16 @@ TEST(json_from_json_missing_fields) {
         ],
         "links": []
     })");
-    PresetData p;
-    from_json(j, p);
-    ASSERT_EQ(p.nodes.size(), 1u);
-    ASSERT_EQ(p.nodes[0].id, "n1");
-    ASSERT_TRUE(p.nodes[0].enabled); 
-    ASSERT_EQ(p.nodes[0].mix, 1.0f);
+  PresetData p;
+  from_json(j, p);
+  ASSERT_EQ(p.nodes.size(), 1u);
+  ASSERT_EQ(p.nodes[0].id, "n1");
+  ASSERT_TRUE(p.nodes[0].enabled);
+  ASSERT_EQ(p.nodes[0].mix, 1.0f);
 }
 
 TEST(json_from_json_invalid_types_skipped) {
-    nlohmann::json j = nlohmann::json::parse(R"({
+  nlohmann::json j = nlohmann::json::parse(R"({
         "type": "Delay",
         "params": {
             "Valid": 1.0,
@@ -536,17 +536,17 @@ TEST(json_from_json_invalid_types_skipped) {
             "InvalidMeta": 123
         }
     })");
-    PresetData::EffectData fx;
-    from_json(j, fx);
-    
-    ASSERT_EQ(fx.params.size(), 1u);
-    ASSERT_EQ(fx.params[0].first, "Valid");
-    ASSERT_EQ(fx.metadata.size(), 1u);
-    ASSERT_EQ(fx.metadata["ValidMeta"], "string");
+  PresetData::EffectData fx;
+  from_json(j, fx);
+
+  ASSERT_EQ(fx.params.size(), 1u);
+  ASSERT_EQ(fx.params[0].first, "Valid");
+  ASSERT_EQ(fx.metadata.size(), 1u);
+  ASSERT_EQ(fx.metadata["ValidMeta"], "string");
 }
 
 TEST(json_from_json_node_invalid_types_skipped) {
-    nlohmann::json j = nlohmann::json::parse(R"({
+  nlohmann::json j = nlohmann::json::parse(R"({
         "routing": "graph",
         "name": "Test",
         "nodes": [
@@ -565,19 +565,19 @@ TEST(json_from_json_node_invalid_types_skipped) {
         ],
         "links": []
     })");
-    PresetData p;
-    from_json(j, p);
-    
-    ASSERT_EQ(p.nodes.size(), 1u);
-    ASSERT_EQ(p.nodes[0].params.size(), 1u);
-    ASSERT_EQ(p.nodes[0].params[0].first, "Valid");
-    ASSERT_EQ(p.nodes[0].metadata.size(), 1u);
-    ASSERT_EQ(p.nodes[0].metadata["ValidMeta"], "string");
+  PresetData p;
+  from_json(j, p);
+
+  ASSERT_EQ(p.nodes.size(), 1u);
+  ASSERT_EQ(p.nodes[0].params.size(), 1u);
+  ASSERT_EQ(p.nodes[0].params[0].first, "Valid");
+  ASSERT_EQ(p.nodes[0].metadata.size(), 1u);
+  ASSERT_EQ(p.nodes[0].metadata["ValidMeta"], "string");
 }
 
 TEST(json_from_ordered_json_invalid_types_skipped) {
-    PresetData p;
-    bool ok = from_json_ext(R"({
+  PresetData p;
+  bool ok = from_json_ext(R"({
         "format_version": 2,
         "routing": "graph",
         "name": "Test",
@@ -596,19 +596,20 @@ TEST(json_from_ordered_json_invalid_types_skipped) {
             }
         ],
         "links": []
-    })", p);
-    
-    ASSERT_TRUE(ok);
-    ASSERT_EQ(p.nodes.size(), 1u);
-    ASSERT_EQ(p.nodes[0].params.size(), 1u);
-    ASSERT_EQ(p.nodes[0].params[0].first, "Valid");
-    ASSERT_EQ(p.nodes[0].metadata.size(), 1u);
-    ASSERT_EQ(p.nodes[0].metadata["ValidMeta"], "string");
+    })",
+                          p);
+
+  ASSERT_TRUE(ok);
+  ASSERT_EQ(p.nodes.size(), 1u);
+  ASSERT_EQ(p.nodes[0].params.size(), 1u);
+  ASSERT_EQ(p.nodes[0].params[0].first, "Valid");
+  ASSERT_EQ(p.nodes[0].metadata.size(), 1u);
+  ASSERT_EQ(p.nodes[0].metadata["ValidMeta"], "string");
 }
 
 TEST(json_from_ordered_json_effect_invalid_types_skipped) {
-    PresetData p;
-    bool ok = from_json_ext(R"({
+  PresetData p;
+  bool ok = from_json_ext(R"({
         "format_version": 2,
         "routing": "linear",
         "name": "Test",
@@ -625,27 +626,28 @@ TEST(json_from_ordered_json_effect_invalid_types_skipped) {
                 }
             }
         ]
-    })", p);
-    
-    ASSERT_TRUE(ok);
-    ASSERT_EQ(p.effects.size(), 1u);
-    ASSERT_EQ(p.effects[0].params.size(), 1u);
-    ASSERT_EQ(p.effects[0].metadata.size(), 1u);
+    })",
+                          p);
+
+  ASSERT_TRUE(ok);
+  ASSERT_EQ(p.effects.size(), 1u);
+  ASSERT_EQ(p.effects[0].params.size(), 1u);
+  ASSERT_EQ(p.effects[0].metadata.size(), 1u);
 }
 
 TEST(json_to_json_linear_routing) {
-    PresetData p;
-    p.routing = "linear";
-    p.effects.push_back({"Delay", true, 0.5f, {{"Time", 0.5f}}, {}});
-    
-    nlohmann::json j = p; // Uses to_json ADL hook
-    ASSERT_TRUE(j.contains("effects"));
-    ASSERT_EQ(j["effects"].size(), 1u);
-    ASSERT_EQ(j["effects"][0]["type"], "Delay");
+  PresetData p;
+  p.routing = "linear";
+  p.effects.push_back({"Delay", true, 0.5f, {{"Time", 0.5f}}, {}});
+
+  nlohmann::json j = p; // Uses to_json ADL hook
+  ASSERT_TRUE(j.contains("effects"));
+  ASSERT_EQ(j["effects"].size(), 1u);
+  ASSERT_EQ(j["effects"][0]["type"], "Delay");
 }
 
 TEST(json_from_json_skips_empty_type) {
-    nlohmann::json j = nlohmann::json::parse(R"({
+  nlohmann::json j = nlohmann::json::parse(R"({
         "routing": "linear",
         "effects": [
             { "type": "" },
@@ -662,19 +664,19 @@ TEST(json_from_json_skips_empty_type) {
             { "src_pin": "n1.out", "dst_pin": "n2.in" }
         ]
     })");
-    PresetData p;
-    from_json(j, p);
-    
-    ASSERT_EQ(p.effects.size(), 1u);
-    ASSERT_EQ(p.effects[0].type, "Valid");
-    ASSERT_EQ(p.nodes.size(), 1u);
-    ASSERT_EQ(p.nodes[0].id, "n3");
-    ASSERT_EQ(p.links.size(), 1u);
+  PresetData p;
+  from_json(j, p);
+
+  ASSERT_EQ(p.effects.size(), 1u);
+  ASSERT_EQ(p.effects[0].type, "Valid");
+  ASSERT_EQ(p.nodes.size(), 1u);
+  ASSERT_EQ(p.nodes[0].id, "n3");
+  ASSERT_EQ(p.links.size(), 1u);
 }
 
 TEST(json_from_ordered_json_skips_empty_type) {
-    PresetData p;
-    bool ok = from_json_ext(R"({
+  PresetData p;
+  bool ok = from_json_ext(R"({
         "format_version": 2,
         "routing": "linear",
         "effects": [
@@ -691,56 +693,57 @@ TEST(json_from_ordered_json_skips_empty_type) {
             { "src_pin": "n1.out", "dst_pin": "" },
             { "src_pin": "n1.out", "dst_pin": "n2.in" }
         ]
-    })", p);
-    
-    ASSERT_TRUE(ok);
-    ASSERT_EQ(p.effects.size(), 1u);
-    ASSERT_EQ(p.nodes.size(), 1u);
-    ASSERT_EQ(p.links.size(), 1u);
+    })",
+                          p);
+
+  ASSERT_TRUE(ok);
+  ASSERT_EQ(p.effects.size(), 1u);
+  ASSERT_EQ(p.nodes.size(), 1u);
+  ASSERT_EQ(p.links.size(), 1u);
 }
 
 TEST(json_from_json_missing_nodes_throws) {
-    nlohmann::json j = nlohmann::json::parse(R"({"routing": "graph"})");
-    PresetData p;
-    ASSERT_THROW(from_json(j, p), std::invalid_argument);
+  nlohmann::json j = nlohmann::json::parse(R"({"routing": "graph"})");
+  PresetData p;
+  ASSERT_THROW(from_json(j, p), std::invalid_argument);
 }
 
 TEST(json_from_json_missing_links_throws) {
-    nlohmann::json j = nlohmann::json::parse(R"({"routing": "graph", "nodes": []})");
-    PresetData p;
-    ASSERT_THROW(from_json(j, p), std::invalid_argument);
-}TEST(json_midi_mapping) {
-    PresetData p;
-    p.routing = "linear";
-    MidiMapping m;
-    m.cc_number = 7;
-    m.midi_channel = 1;
-    m.target_type = MidiTargetType::EffectParam;
-    m.mode = MidiMappingMode::Continuous;
-    m.effect_name = "Delay";
-    m.param_name = "Mix";
-    p.midi_mappings.push_back(m);
-    
-    std::string json_str = to_json_ext(p);
-    PresetData p2;
-    from_json_ext(json_str, p2);
-    
-    ASSERT_EQ(p2.midi_mappings.size(), 1u);
-    ASSERT_EQ(p2.midi_mappings[0].cc_number, 7);
-    ASSERT_EQ(p2.midi_mappings[0].midi_channel, 1);
-    ASSERT_EQ(p2.midi_mappings[0].effect_name, "Delay");
-    ASSERT_EQ(p2.midi_mappings[0].param_name, "Mix");
+  nlohmann::json j =
+      nlohmann::json::parse(R"({"routing": "graph", "nodes": []})");
+  PresetData p;
+  ASSERT_THROW(from_json(j, p), std::invalid_argument);
+}
+TEST(json_midi_mapping) {
+  PresetData p;
+  p.routing = "linear";
+  MidiMapping m;
+  m.cc_number = 7;
+  m.midi_channel = 1;
+  m.target_type = MidiTargetType::EffectParam;
+  m.mode = MidiMappingMode::Continuous;
+  m.effect_name = "Delay";
+  m.param_name = "Mix";
+  p.midi_mappings.push_back(m);
+
+  std::string json_str = to_json_ext(p);
+  PresetData p2;
+  from_json_ext(json_str, p2);
+
+  ASSERT_EQ(p2.midi_mappings.size(), 1u);
+  ASSERT_EQ(p2.midi_mappings[0].cc_number, 7);
+  ASSERT_EQ(p2.midi_mappings[0].midi_channel, 1);
+  ASSERT_EQ(p2.midi_mappings[0].effect_name, "Delay");
+  ASSERT_EQ(p2.midi_mappings[0].param_name, "Mix");
 }
 
 TEST(json_midi_mapping_missing_fields) {
-    nlohmann::json j = nlohmann::json::parse(R"({"routing": "linear", "midi_mappings": [{}]})");
-    PresetData p;
-    from_json(j, p);
-    ASSERT_EQ(p.midi_mappings.size(), 1u);
-    ASSERT_EQ(p.midi_mappings[0].cc_number, 0);
-    ASSERT_EQ(p.midi_mappings[0].midi_channel, -1);
-    ASSERT_EQ(p.midi_mappings[0].effect_name, "");
+  nlohmann::json j =
+      nlohmann::json::parse(R"({"routing": "linear", "midi_mappings": [{}]})");
+  PresetData p;
+  from_json(j, p);
+  ASSERT_EQ(p.midi_mappings.size(), 1u);
+  ASSERT_EQ(p.midi_mappings[0].cc_number, 0);
+  ASSERT_EQ(p.midi_mappings[0].midi_channel, -1);
+  ASSERT_EQ(p.midi_mappings[0].effect_name, "");
 }
-
-
-

--- a/tests/ui/test_pedal_board_menu.cpp
+++ b/tests/ui/test_pedal_board_menu.cpp
@@ -1,182 +1,191 @@
-#include "test_framework.h"
 #include "test_fixtures.h"
+#include "test_framework.h"
 #include <memory>
 
-#include "midi/midi_manager.h"
+#include "audio/effects/amp_simulator.h"
+#include "audio/effects/overdrive.h"
+#include "gui/commands/command_history.h"
 #include "gui/pedalboard/pedal_board.h"
 #include "gui/pedalboard/pedal_widget.h"
 #include "gui/views/gui_midi.h"
-#include "gui/commands/command_history.h"
-#include "audio/effects/overdrive.h"
-#include "audio/effects/amp_simulator.h"
+#include "midi/midi_manager.h"
 
 using namespace Amplitron;
 using namespace TestFramework;
 
 namespace Amplitron {
 struct TestAccessor {
-    static bool& learn_active(MidiManager& m) { return m.learn_active_; }
-    static int& current_port(MidiManager& m) { return m.current_port_; }
-    static std::string& current_port_name(MidiManager& m) { return m.current_port_name_; }
+  static bool &learn_active(MidiManager &m) { return m.learn_active_; }
+  static int &current_port(MidiManager &m) { return m.current_port_; }
+  static std::string &current_port_name(MidiManager &m) {
+    return m.current_port_name_;
+  }
 
-    static void render_add_pedal_menu(PedalBoard& b) { b.render_add_pedal_menu(); }
-    static void render_amp_selector(PedalBoard& b) { b.render_amp_selector(); }
-    static void render_midi_menu(PedalBoard& b) { b.render_midi_menu(); }
-    static void add_effect_and_show(PedalBoard& b, std::shared_ptr<Effect> effect) { b.add_effect_and_show(effect); }
+  static void render_add_pedal_menu(PedalBoard &b) {
+    b.render_add_pedal_menu();
+  }
+  static void render_amp_selector(PedalBoard &b) { b.render_amp_selector(); }
+  static void render_midi_menu(PedalBoard &b) { b.render_midi_menu(); }
+  static void add_effect_and_show(PedalBoard &b,
+                                  std::shared_ptr<Effect> effect) {
+    b.add_effect_and_show(effect);
+  }
 };
-}
+} // namespace Amplitron
 
-// Reusable helper to complete the current frame and begin a new one within a TestWindow context
+// Reusable helper to complete the current frame and begin a new one within a
+// TestWindow context
 static inline void advance_frame() {
-    ImGui::End();
-    ImGui::Render();
-    ImGui::NewFrame();
-    ImGui::SetNextWindowPos(ImVec2(0, 0));
-    ImGui::SetNextWindowSize(ImVec2(1024, 768));
-    ImGui::Begin("TestWindow");
+  ImGui::End();
+  ImGui::Render();
+  ImGui::NewFrame();
+  ImGui::SetNextWindowPos(ImVec2(0, 0));
+  ImGui::SetNextWindowSize(ImVec2(1024, 768));
+  ImGui::Begin("TestWindow");
 }
 
 TEST_F(PresetTest, test_pedal_board_menu_add_pedal_popup) {
-    ScopedImGuiContext imgui;
-    AudioEngine engine;
-    engine.initialize();
-    CommandHistory history;
-    MidiManager midi_manager;
-    GuiMidi gui_midi(midi_manager);
+  ScopedImGuiContext imgui;
+  AudioEngine engine;
+  engine.initialize();
+  CommandHistory history;
+  MidiManager midi_manager;
+  GuiMidi gui_midi(midi_manager);
 
-    PedalBoard board(engine, history, &gui_midi);
+  PedalBoard board(engine, history, &gui_midi);
 
-    ImGui::SetNextWindowPos(ImVec2(0, 0));
-    ImGui::SetNextWindowSize(ImVec2(1024, 768));
-    ImGui::Begin("TestWindow");
+  ImGui::SetNextWindowPos(ImVec2(0, 0));
+  ImGui::SetNextWindowSize(ImVec2(1024, 768));
+  ImGui::Begin("TestWindow");
 
-    // 1. Trigger Add Pedal button and open the popup
-    TestAccessor::render_add_pedal_menu(board);
-    advance_frame();
+  // 1. Trigger Add Pedal button and open the popup
+  TestAccessor::render_add_pedal_menu(board);
+  advance_frame();
 
-    ImGui::OpenPopup("AddPedalPopup");
-    TestAccessor::render_add_pedal_menu(board);
-    advance_frame();
+  ImGui::OpenPopup("AddPedalPopup");
+  TestAccessor::render_add_pedal_menu(board);
+  advance_frame();
 
-    // Trigger individual MenuItems explicitly
-    if (ImGui::BeginPopup("AddPedalPopup")) {
-        // Trigger DRIVE
-        ImGui::MenuItem("Overdrive");
-        ImGui::MenuItem("Distortion");
-        
-        // Trigger DYNAMICS
-        ImGui::MenuItem("Noise Gate");
-        ImGui::MenuItem("Compressor");
-        ImGui::MenuItem("MultiBand Compressor");
+  // Trigger individual MenuItems explicitly
+  if (ImGui::BeginPopup("AddPedalPopup")) {
+    // Trigger DRIVE
+    ImGui::MenuItem("Overdrive");
+    ImGui::MenuItem("Distortion");
 
-        // Trigger MODULATION
-        ImGui::MenuItem("Chorus");
-        ImGui::MenuItem("Phaser");
-        ImGui::MenuItem("Flanger");
+    // Trigger DYNAMICS
+    ImGui::MenuItem("Noise Gate");
+    ImGui::MenuItem("Compressor");
+    ImGui::MenuItem("MultiBand Compressor");
 
-        // Trigger TIME
-        ImGui::MenuItem("Delay");
-        ImGui::MenuItem("Reverb");
-        ImGui::MenuItem("Looper");
+    // Trigger MODULATION
+    ImGui::MenuItem("Chorus");
+    ImGui::MenuItem("Phaser");
+    ImGui::MenuItem("Flanger");
 
-        // Trigger FILTER
-        ImGui::MenuItem("Wah");
+    // Trigger TIME
+    ImGui::MenuItem("Delay");
+    ImGui::MenuItem("Reverb");
+    ImGui::MenuItem("Looper");
 
-        // Trigger PITCH
-        ImGui::MenuItem("Octaver");
-        ImGui::MenuItem("Pitch Shifter");
+    // Trigger FILTER
+    ImGui::MenuItem("Wah");
 
-        // Trigger TONE
-        ImGui::MenuItem("Equalizer");
-        ImGui::MenuItem("Cabinet Sim");
+    // Trigger PITCH
+    ImGui::MenuItem("Octaver");
+    ImGui::MenuItem("Pitch Shifter");
 
-        // Trigger Routing Utility Blocks
-        ImGui::MenuItem("+ Signal Splitter Node (1 In -> 2 Out)");
-        ImGui::MenuItem("+ Signal Mixer Node (2 In -> 1 Out)");
+    // Trigger TONE
+    ImGui::MenuItem("Equalizer");
+    ImGui::MenuItem("Cabinet Sim");
 
-        ImGui::EndPopup();
-    }
-    
-    // Explicitly call the callbacks by calling add_effect_and_show to exercise that path
-    TestAccessor::add_effect_and_show(board, std::make_shared<Overdrive>());
+    // Trigger Routing Utility Blocks
+    ImGui::MenuItem("+ Signal Splitter Node (1 In -> 2 Out)");
+    ImGui::MenuItem("+ Signal Mixer Node (2 In -> 1 Out)");
 
-    ImGui::End();
-    engine.shutdown();
+    ImGui::EndPopup();
+  }
+
+  // Explicitly call the callbacks by calling add_effect_and_show to exercise
+  // that path
+  TestAccessor::add_effect_and_show(board, std::make_shared<Overdrive>());
+
+  ImGui::End();
+  engine.shutdown();
 }
 
 TEST_F(PresetTest, test_pedal_board_menu_amp_selector_popup) {
-    ScopedImGuiContext imgui;
-    AudioEngine engine;
-    engine.initialize();
-    CommandHistory history;
-    MidiManager midi_manager;
-    GuiMidi gui_midi(midi_manager);
+  ScopedImGuiContext imgui;
+  AudioEngine engine;
+  engine.initialize();
+  CommandHistory history;
+  MidiManager midi_manager;
+  GuiMidi gui_midi(midi_manager);
 
-    PedalBoard board(engine, history, &gui_midi);
-    board.rebuild_widgets();
+  PedalBoard board(engine, history, &gui_midi);
+  board.rebuild_widgets();
 
-    ImGui::SetNextWindowPos(ImVec2(0, 0));
-    ImGui::SetNextWindowSize(ImVec2(1024, 768));
-    ImGui::Begin("TestWindow");
+  ImGui::SetNextWindowPos(ImVec2(0, 0));
+  ImGui::SetNextWindowSize(ImVec2(1024, 768));
+  ImGui::Begin("TestWindow");
 
-    // 1. Initial amp selector button render
-    TestAccessor::render_amp_selector(board);
-    advance_frame();
+  // 1. Initial amp selector button render
+  TestAccessor::render_amp_selector(board);
+  advance_frame();
 
-    // 2. Open popup and trigger selection
-    ImGui::OpenPopup("AmpSelectorPopup");
-    TestAccessor::render_amp_selector(board);
-    advance_frame();
+  // 2. Open popup and trigger selection
+  ImGui::OpenPopup("AmpSelectorPopup");
+  TestAccessor::render_amp_selector(board);
+  advance_frame();
 
-    if (ImGui::BeginPopup("AmpSelectorPopup")) {
-        ImGui::MenuItem("Plexi 50W");
-        ImGui::EndPopup();
-    }
+  if (ImGui::BeginPopup("AmpSelectorPopup")) {
+    ImGui::MenuItem("Plexi 50W");
+    ImGui::EndPopup();
+  }
 
-    ImGui::End();
-    engine.shutdown();
+  ImGui::End();
+  engine.shutdown();
 }
 
 TEST_F(PresetTest, test_pedal_board_menu_midi_popup) {
-    ScopedImGuiContext imgui;
-    AudioEngine engine;
-    engine.initialize();
-    CommandHistory history;
-    MidiManager midi_manager;
-    GuiMidi gui_midi(midi_manager);
+  ScopedImGuiContext imgui;
+  AudioEngine engine;
+  engine.initialize();
+  CommandHistory history;
+  MidiManager midi_manager;
+  GuiMidi gui_midi(midi_manager);
 
-    PedalBoard board(engine, history, &gui_midi);
+  PedalBoard board(engine, history, &gui_midi);
 
-    ImGui::SetNextWindowPos(ImVec2(0, 0));
-    ImGui::SetNextWindowSize(ImVec2(1024, 768));
-    ImGui::Begin("TestWindow");
+  ImGui::SetNextWindowPos(ImVec2(0, 0));
+  ImGui::SetNextWindowSize(ImVec2(1024, 768));
+  ImGui::Begin("TestWindow");
 
-    // 1. Midi button rendering
-    TestAccessor::render_midi_menu(board);
-    advance_frame();
+  // 1. Midi button rendering
+  TestAccessor::render_midi_menu(board);
+  advance_frame();
 
-    // 2. Open popup and render connected state
-    TestAccessor::learn_active(gui_midi.manager()) = false;
-    TestAccessor::current_port(gui_midi.manager()) = 0;
-    TestAccessor::current_port_name(gui_midi.manager()) = "Test MIDI Port";
-    ImGui::OpenPopup("MidiMenuPopup");
-    TestAccessor::render_midi_menu(board);
-    advance_frame();
+  // 2. Open popup and render connected state
+  TestAccessor::learn_active(gui_midi.manager()) = false;
+  TestAccessor::current_port(gui_midi.manager()) = 0;
+  TestAccessor::current_port_name(gui_midi.manager()) = "Test MIDI Port";
+  ImGui::OpenPopup("MidiMenuPopup");
+  TestAccessor::render_midi_menu(board);
+  advance_frame();
 
-    // 3. Render learning state in MIDI popup
-    TestAccessor::learn_active(gui_midi.manager()) = true;
-    TestAccessor::render_midi_menu(board);
-    advance_frame();
+  // 3. Render learning state in MIDI popup
+  TestAccessor::learn_active(gui_midi.manager()) = true;
+  TestAccessor::render_midi_menu(board);
+  advance_frame();
 
-    // 4. Exercise menu choices inside the popup
-    if (ImGui::BeginPopup("MidiMenuPopup")) {
-        ImGui::MenuItem("Cancel Learn Mode");
-        ImGui::MenuItem("Clear All Mappings");
-        ImGui::MenuItem("Save Config");
-        ImGui::MenuItem("Load Config");
-        ImGui::EndPopup();
-    }
+  // 4. Exercise menu choices inside the popup
+  if (ImGui::BeginPopup("MidiMenuPopup")) {
+    ImGui::MenuItem("Cancel Learn Mode");
+    ImGui::MenuItem("Clear All Mappings");
+    ImGui::MenuItem("Save Config");
+    ImGui::MenuItem("Load Config");
+    ImGui::EndPopup();
+  }
 
-    ImGui::End();
-    engine.shutdown();
+  ImGui::End();
+  engine.shutdown();
 }


### PR DESCRIPTION
## What does this PR do?

This PR upgrades the existing 2-input Mixer node into a fully dynamic N-input Mixer (supporting 2 to 8 input pins). It allows users to build complex parallel routing topologies, such as blending a clean amp, a distorted amp, and a direct signal simultaneously. It also introduces independent, MIDI-learnable gain faders for each channel, fully integrated with the lock-free SPSC command queue to ensure glitch-free updates on the real-time audio thread.

## Related Issue

Fixes #147

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [x] ♻️ Refactor / code cleanup
- [ ] 📝 Documentation
- [x] ✅ Tests
- [ ] 🔧 Build / CI / Configuration

## How Was This Tested?

- Platform(s) tested on: Linux (Ubuntu)
- Test command run: `make && ./build/amplitron-tests`
- Manual test steps (if applicable):
  1. Opened the GUI and spawned an N-in Mixer from the creation menu.
  2. Right-clicked the mixer to verify dynamic addition and removal of input pins via the context menu.
  3. Verified that pin removal is correctly blocked when an active cable is connected to it.
  4. Adjusted the newly labeled `(Gain Fader)` sliders while passing audio to verify zero-glitch volume scaling.
  5. Mapped a MIDI controller to the gain faders and verified real-time manipulation.
  6. Saved and loaded a preset to ensure dynamic pin counts and gain values persist correctly.

## Checklist

- [x] Code compiles and builds successfully on my platform
- [x] All existing tests pass (`./amplitron-tests`)
- [x] New tests added for new functionality (if applicable)
- [ ] Documentation updated (README, code comments) if applicable
- [x] No blocking calls on the audio thread (no `std::mutex::lock()` on the hot path)
- [x] Tested on: Linux

## Screenshots / Demo
<img width="1920" height="1080" alt="Screenshot from 2026-05-28 21-39-35" src="https://github.com/user-attachments/assets/12f10be8-8c9e-4809-8a71-d8e24dd2619e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mixers support dynamic N-inputs (2–8) with per-input gain sliders, MIDI mapping, and menu label updates.
  * Splitters support dynamic N-outputs.
  * UI: smoother canvas zoom/scroll (cursor-anchored zoom), fullscreen toggle, optional grid, animated visuals and improved node layout/drag.

* **Behavior**
  * Pins auto-added/removed when wiring changes with undo/redo restoring pins; gains clamped and applied in real time.

* **Tests**
  * Added integration tests for multi-input mixers and per-input gains.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sudip-mondal-2002/Amplitron/pull/277?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->