### PR TITLE
Add Codecov integration for coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,11 @@ jobs:
             coverage.filtered.info
             coverage-summary.txt
           retention-days: 7
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+        files: ./coverage.filtered.info
+        fail_ci_if_error: false
 
       
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,12 +199,11 @@ jobs:
             coverage.filtered.info
             coverage-summary.txt
           retention-days: 7
-      - name: Upload coverage to Codecov
+      - name: Upload Coverage to codecov
         uses: codecov/codecov-action@v4
         with:
-        files: ./coverage.filtered.info
-        fail_ci_if_error: false
-
+          files: ./coverage.filtered.info
+          fail_ci_if_error: false
       
 
   test-macos:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 
 [![CI Build](https://github.com/sudip-mondal-2002/Amplitron/actions/workflows/ci.yml/badge.svg)](https://github.com/sudip-mondal-2002/Amplitron/actions/workflows/ci.yml)
-[![Coverage](https://img.shields.io/badge/coverage-report-blue)](https://github.com/sudip-mondal-2002/Amplitron/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/sudip-mondal-2002/Amplitron/branch/main/graph/badge.svg)](https://codecov.io/gh/sudip-mondal-2002/Amplitron)
 [![Release](https://github.com/sudip-mondal-2002/Amplitron/actions/workflows/release.yml/badge.svg)](https://github.com/sudip-mondal-2002/Amplitron/actions/workflows/release.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux%20%7C%20Android%20%7C%20iOS-blue)](https://github.com/sudip-mondal-2002/Amplitron/releases)


### PR DESCRIPTION
## What does this PR do?

Replaces the static coverage badge in the README with a dynamic Codecov coverage badge and adds Codecov integration to the CI workflow for automatic coverage reporting.

## Related Issue

Fixes #275

## Type of Change

📝 Documentation
🔧 Build / CI / Configuration

## How Was This Tested?

* Platform(s) tested on: Windows 11
* Verified README badge replacement
* Verified workflow YAML formatting
* Verified Codecov upload step placement

## Checklist

* Documentation updated
* Tested on Windows 11

## Screenshots / Demo

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now uploads coverage reports to Codecov (upload errors won’t fail the CI job).
  * Replaced the generic coverage badge in the README with a Codecov badge for main-branch coverage visibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sudip-mondal-2002/Amplitron/pull/279?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->