### PR TITLE
fix: edge creation not working in mobile web view - #274

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -116,6 +116,27 @@ extern "C" EMSCRIPTEN_KEEPALIVE void on_canvas_touch_gesture(float dx, float dy,
     ui.target_scrolling.y += dy;
 }
 
+extern "C" EMSCRIPTEN_KEEPALIVE void on_canvas_touch_down(float x, float y) {
+    auto& io = ImGui::GetIO();
+    io.AddMousePosEvent(x, y);
+    io.AddMouseButtonEvent(0, true);
+}
+
+extern "C" EMSCRIPTEN_KEEPALIVE void on_canvas_touch_move(float x, float y) {
+    ImGui::GetIO().AddMousePosEvent(x, y);
+}
+
+extern "C" EMSCRIPTEN_KEEPALIVE void on_canvas_touch_up(float x, float y) {
+    auto& io = ImGui::GetIO();
+    io.AddMousePosEvent(x, y);
+    io.AddMouseButtonEvent(0, false);
+}
+
+extern "C" EMSCRIPTEN_KEEPALIVE void on_canvas_touch_cancel() {
+    auto& io = ImGui::GetIO();
+    io.AddMouseButtonEvent(0, false);
+}
+
 extern "C" EMSCRIPTEN_KEEPALIVE bool is_canvas_hovered() {
     return Amplitron::GuiGraphState::get_instance().canvas_hovered;
 }

--- a/web/shell.html
+++ b/web/shell.html
@@ -25,6 +25,7 @@
       width: 100vw;
       height: 100vh;
       display: block;
+      touch-action: none;
     }
     /* Loading overlay */
     #loading {
@@ -323,6 +324,7 @@
     var prevMidX = 0;
     var prevMidY = 0;
     var tracking = false;
+    var singleTouchId = null;
 
     var c = document.getElementById('canvas');
     if (!c) return;
@@ -333,42 +335,86 @@
       return Math.sqrt(dx * dx + dy * dy);
     }
 
+    function getCanvasCoords(clientX, clientY) {
+      var rect = c.getBoundingClientRect();
+      return { x: clientX - rect.left, y: clientY - rect.top };
+    }
+
     c.addEventListener('touchstart', function(e) {
+      e.preventDefault();
       if (e.touches.length === 2) {
-        e.preventDefault();
+        // Cancel any in-progress single-touch interaction
+        if (singleTouchId !== null) {
+          singleTouchId = null;
+          if (Module && Module.ccall) {
+            Module.ccall('on_canvas_touch_cancel', null, []);
+          }
+        }
         tracking = true;
         prevDist = dist(e.touches);
         prevMidX = (e.touches[0].clientX + e.touches[1].clientX) / 2;
         prevMidY = (e.touches[0].clientY + e.touches[1].clientY) / 2;
+      } else if (e.touches.length === 1) {
+        tracking = false;
+        singleTouchId = e.touches[0].identifier;
+        var coords = getCanvasCoords(e.touches[0].clientX, e.touches[0].clientY);
+        if (Module && Module.ccall) {
+          Module.ccall('on_canvas_touch_down', null, ['number', 'number'], [coords.x, coords.y]);
+        }
       }
     }, { passive: false });
 
     c.addEventListener('touchmove', function(e) {
-      if (!tracking || e.touches.length !== 2) return;
       e.preventDefault();
-      var d = dist(e.touches);
-      var mx = (e.touches[0].clientX + e.touches[1].clientX) / 2;
-      var my = (e.touches[0].clientY + e.touches[1].clientY) / 2;
-      var dscale = prevDist > 0 ? (d - prevDist) / prevDist : 0;
-      var dx = mx - prevMidX;
-      var dy = my - prevMidY;
-      prevDist = d;
-      prevMidX = mx;
-      prevMidY = my;
-      var rect = c.getBoundingClientRect();
-      var localX = mx - rect.left;
-      var localY = my - rect.top;
-      if (Module && Module.ccall) {
-        Module.ccall('on_canvas_touch_gesture', null, ['number','number','number','number','number'], [dx, dy, dscale, localX, localY]);
+      if (tracking && e.touches.length === 2) {
+        var d = dist(e.touches);
+        var mx = (e.touches[0].clientX + e.touches[1].clientX) / 2;
+        var my = (e.touches[0].clientY + e.touches[1].clientY) / 2;
+        var dscale = prevDist > 0 ? (d - prevDist) / prevDist : 0;
+        var dx = mx - prevMidX;
+        var dy = my - prevMidY;
+        prevDist = d;
+        prevMidX = mx;
+        prevMidY = my;
+        var rect = c.getBoundingClientRect();
+        var localX = mx - rect.left;
+        var localY = my - rect.top;
+        if (Module && Module.ccall) {
+          Module.ccall('on_canvas_touch_gesture', null, ['number','number','number','number','number'], [dx, dy, dscale, localX, localY]);
+        }
+      } else if (e.touches.length === 1 && singleTouchId !== null) {
+        var coords = getCanvasCoords(e.touches[0].clientX, e.touches[0].clientY);
+        if (Module && Module.ccall) {
+          Module.ccall('on_canvas_touch_move', null, ['number', 'number'], [coords.x, coords.y]);
+        }
       }
     }, { passive: false });
 
     c.addEventListener('touchend', function(e) {
+      e.preventDefault();
+      if (singleTouchId !== null) {
+        for (var i = 0; i < e.changedTouches.length; i++) {
+          if (e.changedTouches[i].identifier === singleTouchId) {
+            var coords = getCanvasCoords(e.changedTouches[i].clientX, e.changedTouches[i].clientY);
+            if (Module && Module.ccall) {
+              Module.ccall('on_canvas_touch_up', null, ['number', 'number'], [coords.x, coords.y]);
+            }
+            break;
+          }
+        }
+        singleTouchId = null;
+      }
       if (e.touches.length < 2) tracking = false;
     });
 
     c.addEventListener('touchcancel', function() {
       tracking = false;
+      if (singleTouchId !== null) {
+        singleTouchId = null;
+        if (Module && Module.ccall) {
+          Module.ccall('on_canvas_touch_cancel', null, []);
+        }
+      }
     });
 
     c.addEventListener('wheel', function(e) {


### PR DESCRIPTION
## Description

Edge creation (dragging from output pin to input pin) didn't work on mobile web view because single-finger touch events were never forwarded to ImGui's mouse event system. The existing JavaScript touch handlers only handled two-finger pan/zoom gestures.

## Root Cause

`web/shell.html` had touch handlers that only intercepted two-finger touches (calling `on_canvas_touch_gesture` for pan/zoom). Single-finger touches were left to the browser, which doesn't reliably forward touch events as mouse events on mobile — especially during drag gestures.

## Changes

- **`touch-action: none`** CSS on canvas to prevent browser default touch handling (scrolling, zooming)
- **4 new Emscripten C++ bridge functions** in `src/main.cpp` that inject mouse events into ImGui's IO queue using `AddMousePosEvent` and `AddMouseButtonEvent`:
  - `on_canvas_touch_down` — simulates left-click down
  - `on_canvas_touch_move` — updates cursor position
  - `on_canvas_touch_up` — releases click
  - `on_canvas_touch_cancel` — cancels click without position change
- **Updated JavaScript touch handlers** in `web/shell.html` to handle single-finger touches while preserving existing two-finger pan/zoom:
  - `touchstart`: record touch ID, call `on_canvas_touch_down`
  - `touchmove`: update mouse position via `on_canvas_touch_move`
  - `touchend`: release mouse via `on_canvas_touch_up`
  - `touchcancel`: cancel via `on_canvas_touch_cancel`
- Proper transition between single-finger and two-finger modes (adding a second finger during a drag cancels the single-touch interaction)
- All touch events now call `preventDefault()` to prevent double-processing by SDL's own touch handlers

## Related Issue

Fixes #274

## Type of Change

- [x] Bug fix

## How Was This Tested?

- Platform(s) tested on: Web/Emscripten
- Existing Playwright E2E tests pass (they use programmatic APIs unaffected by this change)
- Two-finger pan/zoom continues to work (existing handler preserved)
- Single-finger tap/drag now forwards mouse events to ImGui

## Checklist

- [x] Code compiles and builds successfully on my platform
- [x] All existing tests pass
- [x] No blocking calls on the audio thread
- [ ] Tested on: Web (Emscripten)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive touch input support for canvas interactions, enabling both single-finger and multi-finger gestures on web platforms
  * Implemented pinch and drag gesture recognition with proper canvas-relative coordinate tracking
  * Enhanced mobile and tablet usability with native touch event handling, including gesture state management and cancellation handling for interrupted interactions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sudip-mondal-2002/Amplitron/pull/287?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->