### PR TITLE
fix: remove hardcoded magic divisor in Distortion

### DIFF
--- a/src/audio/effects/distortion.cpp
+++ b/src/audio/effects/distortion.cpp
@@ -45,7 +45,7 @@ void Distortion::process(float* buffer, int num_samples) {
         float x_hard = hard_clip(x, 1.0f);
 
         // Blend: more drive → more hard clipping
-        float hard_amount = (drive - 1.0f) / 19.0f; // 0 at drive=1, 1 at drive=20
+        float hard_amount = (drive - params_[0].min_val) / (params_[0].max_val - params_[0].min_val);
         x = x_soft * (1.0f - hard_amount) + x_hard * hard_amount;
 
         // Tone filter (one-pole LP)


### PR DESCRIPTION
## What does this PR do?

Replaced the hardcoded magic divisor 19.0f in the Distortion effect with dynamic range calculation using min_val and max_val.

## Related Issue

<!-- Link to the issue this PR addresses -->
Fixes #283 

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor / code cleanup
- [ ] 📝 Documentation
- [ ] ✅ Tests
- [ ] 🔧 Build / CI / Configuration

## How Was This Tested?

Verified the math/logic fix locally in the code.
- Platform(s) tested on: 
- Test command run: `./amplitron-tests`
- Manual test steps (if applicable):

## Checklist

- [x] Code compiles and builds successfully on my platform
- [ ] All existing tests pass (`./amplitron-tests`)
- [ ] New tests added for new functionality (if applicable)
- [ ] Documentation updated (README, code comments) if applicable
- [ ] No blocking calls on the audio thread (no `std::mutex::lock()` on the hot path)
- [ ] Tested on: (list your OS/platform)

## Screenshots / Demo

<!-- Add screenshots or GIFs if this changes the UI -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the distortion effect's drive parameter scaling to properly use registered parameter range values for hard clipping calculations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sudip-mondal-2002/Amplitron/pull/304?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->