### PR TITLE
feat(gui): replace pixelated learn emoji with clean text label

### DIFF
--- a/src/gui/pedal_board_menu.cpp
+++ b/src/gui/pedal_board_menu.cpp
@@ -188,7 +188,7 @@ void PedalBoard::render_midi_menu() {
 
         // Learn mode status
         if (midi.is_learning()) {
-            ImGui::TextColored(ImVec4(1.0f, 0.8f, 0.0f, 1.0f), "⚡ Learn Mode Active");
+            ImGui::TextColored(ImVec4(1.0f, 0.8f, 0.0f, 1.0f), "[MIDI LEARN ACTIVE]");
             if (ImGui::MenuItem("Cancel Learn Mode", "Esc")) {
                 midi.cancel_learn();
             }


### PR DESCRIPTION
Closes #330 

## What does this PR do?

Replaces the pixelated emoji status tags inside the ImGui MIDI learning setup menu with a clean, high-fidelity [MIDI LEARN ACTIVE] badge.

## How Was This Tested?

- Built the application locally and verified ImGui layout rendering.

## Checklist

- [x] Code compiles and builds successfully
- [x] No blocking calls on the audio thread