### PR TITLE
Refactor link counting to avoid duplicate error messages

### DIFF
--- a/src/audio/engine/audio_graph.cpp
+++ b/src/audio/engine/audio_graph.cpp
@@ -62,12 +62,17 @@ int AudioGraph::add_link(int source_pin_id, int dest_pin_id) {
         if (src_node) {
             // Count existing outgoing links from this specific pin
             int out_count = 0;
-            for (const auto &existing_link : links_) {
-                if (existing_link.source_pin_id == source_pin_id) {
-                    printf("add_link failed: Output pin %d already has an outgoing connection!\n", source_pin_id);
-                    out_count++;
-                }
-            }
+           bool printed = false;
+
+              for (const auto &existing_link : links_) {
+                  if (existing_link.source_pin_id == source_pin_id) {
+                      if (!printed) {
+                          printf("add_link failed: Output pin %d already has an outgoing connection!\n", source_pin_id);
+                          printed = true;
+                      }
+                      out_count++;
+                  }
+              }
             if (out_count >= 1) {
                 return -1; // Each output pin can only have 1 outgoing connection!
             }


### PR DESCRIPTION
Ensure error message for existing links is printed only once.

## What does this PR do?

<!-- Brief description of the change -->

## Related Issue

<!-- Link to the issue this PR addresses -->
Fixes #284

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [x] ♻️ Refactor / code cleanup
- [ ] 📝 Documentation
- [x] ✅ Tests
- [ ] 🔧 Build / CI / Configuration

## How Was This Tested?

<!-- Describe how you tested the change -->
- Platform(s) tested on: 
- Test command run: `./amplitron-tests`
- Manual test steps (if applicable):

## Checklist

- [ ] Code compiles and builds successfully on my platform
- [ ] All existing tests pass (`./amplitron-tests`)
- [ ] New tests added for new functionality (if applicable)
- [ ] Documentation updated (README, code comments) if applicable
- [ ] No blocking calls on the audio thread (no `std::mutex::lock()` on the hot path)
- [ ] Tested on: (list your OS/platform)

## Screenshots / Demo

<!-- Add screenshots or GIFs if this changes the UI -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved audio graph connection validation to display error messages more efficiently, preventing redundant notifications while preserving accurate connection verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->