### PR TITLE
fix: resolve unused parameter warning in render_knobs

### DIFF
--- a/src/gui/pedalboard/pedal_widget_knobs.cpp
+++ b/src/gui/pedalboard/pedal_widget_knobs.cpp
@@ -11,6 +11,7 @@
 namespace Amplitron {
 
 void PedalWidget::render_knobs(ImDrawList* dl, ImVec2 p0, float pedal_width, bool is_amp, bool is_tuner, bool is_ir_cab, float zoom) {
+    (void)dl;
     float knob_y_start = p0.y + Theme::KNOB_Y_START * zoom;
     if (is_ir_cab) knob_y_start = p0.y + 180 * zoom;
     auto& params = effect_->params();

--- a/src/presets/preset_manager_io.cpp
+++ b/src/presets/preset_manager_io.cpp
@@ -460,11 +460,11 @@ bool PresetManager::graph_from_json(const std::string &json,
       try {
         if (p_str.length() > 3 && p_str.substr(0, 3) == "out" && !is_input) {
           int idx = std::stoi(p_str.substr(3));
-          if (idx >= 0 && idx < node->output_pin_ids.size())
+          if (idx >= 0 && static_cast<size_t>(idx) < node->output_pin_ids.size())
             return node->output_pin_ids[idx];
         } else if (p_str.length() > 2 && p_str.substr(0, 2) == "in" && is_input) {
           int idx = std::stoi(p_str.substr(2));
-          if (idx >= 0 && idx < node->input_pin_ids.size())
+          if (idx >= 0 && static_cast<size_t>(idx) < node->input_pin_ids.size())
             return node->input_pin_ids[idx];
         }
       } catch (const std::invalid_argument&) {


### PR DESCRIPTION
## What does this PR do?

<!-- Brief description of the change -->

## Related Issue

<!-- Link to the issue this PR addresses -->
Fixes #

## Type of Change

- [ 
] 🐛 Bug fix
- [ ] ✨ New feature
- [x] ♻️ Refactor / code cleanup
- [ ] ✅ Tests
- [ ] 🔧 Build / CI / Configuration

## How Was This Tested?

<!-- Describe how you tested the change -->
- Platform(s) tested on: 
- Test command run: `./amplitron-tests`
- Manual test steps (if applicable):

## Checklist

- [x] Code compiles and builds successfully on my platform
- [x] All existing tests pass (`./amplitron-tests`)
- [ ] New tests added for new functionality (if applicable)
- [ ] Documentation updated (README, code comments) if applicable
- [x] No blocking calls on the audio thread (no `std::mutex::lock()` on the hot path)
- [ ] Tested on: (list your OS/platform)

## Screenshots / Demo

<!-- Add screenshots or GIFs if this changes the UI -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This release contains internal code quality improvements with no user-facing changes.

* **Chores**
  * Code cleanup and compiler warning reduction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->