### PR TITLE
Improve tooltip handling for snapshot slots

### DIFF
--- a/src/gui/views/gui_snapshots.cpp
+++ b/src/gui/views/gui_snapshots.cpp
@@ -62,13 +62,30 @@ void GuiSnapshots::render() {
         ImGui::PopStyleColor(3);
 
         // Tooltip
+        // Tooltip
         if (ImGui::IsItemHovered()) {
-            if (is_filled)
-                ImGui::SetTooltip("Left-click to recall snapshot %s (or Ctrl+%d)\nRight-click to overwrite or clear", lbl, i + 1);
-            else
-                ImGui::SetTooltip("Slot %s is empty\nRight-click to save current board here", lbl);
+            if (is_filled) {
+        #ifdef __EMSCRIPTEN__
+                ImGui::SetTooltip(
+                    "Tap to load snapshot %s",
+                    lbl);
+        #else
+                ImGui::SetTooltip(
+                    "Left-click to recall snapshot %s (or Ctrl+%d)\nRight-click to overwrite or clear",
+                    lbl, i + 1);
+        #endif
+            } else {
+        #ifdef __EMSCRIPTEN__
+                ImGui::SetTooltip(
+                    "Slot %s is empty",
+                    lbl);
+        #else
+                ImGui::SetTooltip(
+                    "Slot %s is empty\nRight-click to save current board here",
+                    lbl);
+        #endif
+            }
         }
-
         // Right-click context menu
         char popup_id[24];
         std::snprintf(popup_id, sizeof(popup_id), "SnapCtx_%d", i);


### PR DESCRIPTION
Refactor tooltip messages for snapshot slots based on platform.

## What does this PR do?

<!-- Brief description of the change -->

## Related Issue

<!-- Link to the issue this PR addresses -->
Fixes #

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [x] ♻️ Refactor / code cleanup
- [ ] 📝 Documentation
- [ ] ✅ Tests
- [ ] 🔧 Build / CI / Configuration

## How Was This Tested?

<!-- Describe how you tested the change -->
- Platform(s) tested on: 
- Test command run: `./amplitron-tests`
- Manual test steps (if applicable):

## Checklist

- [ ] Code compiles and builds successfully on my platform
- [ ] All existing tests pass (`./amplitron-tests`)
- [ ] New tests added for new functionality (if applicable)
- [ ] Documentation updated (README, code comments) if applicable
- [x] No blocking calls on the audio thread (no `std::mutex::lock()` on the hot path)
- [ ] Tested on: (list your OS/platform)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Improved snapshot button interface with platform-specific tooltip messages for better usability. Web version displays simplified "Tap to load snapshot" and "Slot empty" instructions for touch interaction. Desktop version provides comprehensive guidance including keyboard shortcuts (Ctrl+N) and right-click context menu actions for snapshot management, overwriting, and clearing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->