### PR TITLE
fix: default analyzer_enabled to true on startup

### DIFF
--- a/src/audio/engine/audio_engine.h
+++ b/src/audio/engine/audio_engine.h
@@ -344,7 +344,7 @@ private:
     std::atomic<float> output_rms_{0.0f};
     std::atomic<bool> input_clipped_{false};
     std::atomic<bool> output_clipped_{false};
-    std::atomic<bool> analyzer_enabled_{false};
+    std::atomic<bool> analyzer_enabled_{true};
 
     // std::vector<std::shared_ptr<Effect>> effects_;
     std::vector<float>     process_buffer_;

--- a/src/gui/gui_manager.cpp
+++ b/src/gui/gui_manager.cpp
@@ -48,6 +48,7 @@ GuiManager::GuiManager(AudioEngine& engine)
     pedal_board_ = std::make_unique<PedalBoard>(engine_, command_history_, &gui_midi_);
     gui_presets_.set_pedal_board(pedal_board_.get());
     gui_presets_.set_midi_manager(&midi_manager_);
+    gui_analyzer_.set_expanded(engine_.is_analyzer_enabled());
 }
 
 GuiManager::~GuiManager() {

--- a/src/gui/views/gui_analyzer.cpp
+++ b/src/gui/views/gui_analyzer.cpp
@@ -142,7 +142,8 @@ void GuiAnalyzer::render() {
     float panel_h = expanded_ ? 230.0f : 34.0f;
     ImGui::BeginChild("AnalyzerPanel", ImVec2(0, panel_h), true, ImGuiWindowFlags_NoScrollbar);
 
-    const bool expanded = ImGui::CollapsingHeader("Real-Time Analyzer", ImGuiTreeNodeFlags_DefaultOpen);
+    ImGui::SetNextItemOpen(expanded_, ImGuiCond_Once);
+    const bool expanded = ImGui::CollapsingHeader("Real-Time Analyzer");
     if (expanded != expanded_) {
         expanded_ = expanded;
         if (p.on_expanded_changed) p.on_expanded_changed(expanded_);

--- a/src/gui/views/gui_analyzer.h
+++ b/src/gui/views/gui_analyzer.h
@@ -58,6 +58,7 @@ public:
 
     SpectrumDisplayMode current_mode() const { return mode_; }
     bool is_expanded() const { return expanded_; }
+    void set_expanded(bool expanded) { expanded_ = expanded; }
 
 private:
     void render_vu_bar(const char* id,


### PR DESCRIPTION
### Description
Fixes #345.

At application startup, the Real-Time Spectrum Analyzer UI panel was expanded by default. However, the core audio engine's capture flag (`analyzer_enabled_`) was initialized to `false`.

Because of this, the audio processing callback bypassed capturing input/output samples for the FFT on launch, leaving the analyzer flat until manually toggled (collapsed and re-expanded).

### Solution
1. Initialized `analyzer_enabled_` to `true` by default in `src/audio/engine/audio_engine.h` to align the audio capture state with the default expanded UI state.
2. Refactored the UI startup behavior to address the CodeRabbit review feedback. The initial UI panel expansion state is now driven dynamically from the engine state (querying `engine_.is_analyzer_enabled()` inside `GuiManager` on startup and applying it to the collapsing header via `ImGui::SetNextItemOpen(..., ImGuiCond_Once)`). This prevents future mismatches between the UI and engine defaults.

### Verification
* Built and ran all 694 unit/integration tests successfully.
* Verified that the spectrum analyzer captures and displays real-time frequency data immediately at launch.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Analyzer capture is now enabled by default.

* **New Features**
  * The Real-Time Analyzer panel now initializes open/closed based on the analyzer setting.
  * The analyzer panel preserves and applies the user’s previous expanded/collapsed state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->