### PR TITLE
feat: Add Keyboard Shortcut Help Modal (#348)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,6 +289,7 @@ set(APP_SOURCES
     src/gui/views/gui_presets.cpp
     src/gui/views/gui_recording.cpp
     src/gui/views/gui_tuner.cpp
+    src/gui/views/gui_keyboard_shortcuts.cpp
     src/gui/views/gui_analyzer.cpp
     src/gui/pedalboard/pedal_board.cpp
     src/gui/pedalboard/pedal_board_menu.cpp
@@ -783,6 +784,7 @@ else() # NOT EMSCRIPTEN, ANDROID, or IOS
         tests/ui/test_gui_midi.cpp
         tests/ui/test_gui_recording.cpp
         tests/ui/test_gui_tuner.cpp
+        tests/ui/test_gui_keyboard_shortcuts.cpp
         tests/ui/test_gui_components.cpp
         tests/ui/test_footswitch.cpp
         tests/ui/test_led.cpp
@@ -826,6 +828,7 @@ else() # NOT EMSCRIPTEN, ANDROID, or IOS
         src/gui/views/gui_presets.cpp
         src/gui/views/gui_recording.cpp
         src/gui/views/gui_tuner.cpp
+        src/gui/views/gui_keyboard_shortcuts.cpp
         src/gui/views/gui_analyzer.cpp
         src/gui/pedalboard/pedal_board.cpp
         src/gui/pedalboard/pedal_board_menu.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -953,22 +953,32 @@ else() # NOT EMSCRIPTEN, ANDROID, or IOS
     endif()
 
     # Copy presets into build directory alongside the executable
-    add_custom_target(copy_presets ALL
+    add_custom_command(TARGET Amplitron POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_directory
             "${CMAKE_SOURCE_DIR}/presets"
             "$<TARGET_FILE_DIR:Amplitron>/presets"
         COMMENT "Copying presets to build directory"
     )
-    add_dependencies(copy_presets Amplitron)
+    add_custom_command(TARGET amplitron-tests POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+            "${CMAKE_SOURCE_DIR}/presets"
+            "$<TARGET_FILE_DIR:amplitron-tests>/presets"
+        COMMENT "Copying presets to build directory"
+    )
 
     # Copy fonts into build directory alongside the executable
-    add_custom_target(copy_fonts ALL
+    add_custom_command(TARGET Amplitron POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_directory
             "${CMAKE_SOURCE_DIR}/assets/fonts"
             "$<TARGET_FILE_DIR:Amplitron>/assets/fonts"
         COMMENT "Copying fonts to build directory"
     )
-    add_dependencies(copy_fonts Amplitron)
+    add_custom_command(TARGET amplitron-tests POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+            "${CMAKE_SOURCE_DIR}/assets/fonts"
+            "$<TARGET_FILE_DIR:amplitron-tests>/assets/fonts"
+        COMMENT "Copying fonts to build directory"
+    )
 
     # Install
     install(TARGETS Amplitron RUNTIME DESTINATION bin)

--- a/src/gui/gui_manager.h
+++ b/src/gui/gui_manager.h
@@ -11,13 +11,13 @@
 #include "gui/commands/command_history.h"
 #include "gui/state/snapshot_manager.h"
 #include "gui/views/gui_analyzer.h"
+#include "gui/views/gui_keyboard_shortcuts.h"
 #include "gui/views/gui_midi.h"
 #include "gui/views/gui_presets.h"
 #include "gui/views/gui_recording.h"
 #include "gui/views/gui_settings.h"
 #include "gui/views/gui_snapshots.h"
 #include "gui/views/gui_tuner.h"
-#include "gui/views/gui_keyboard_shortcuts.h"
 #include "midi/midi_manager.h"
 
 struct SDL_Window;

--- a/src/gui/gui_manager.h
+++ b/src/gui/gui_manager.h
@@ -17,6 +17,7 @@
 #include "gui/views/gui_settings.h"
 #include "gui/views/gui_snapshots.h"
 #include "gui/views/gui_tuner.h"
+#include "gui/views/gui_keyboard_shortcuts.h"
 #include "midi/midi_manager.h"
 
 struct SDL_Window;
@@ -109,6 +110,7 @@ class GuiManager {
     bool show_load_preset_ = false;
     bool show_tuner_ = false;
     bool show_midi_ = false;
+    bool show_keyboard_shortcuts_ = false;
 
     // ── Snapshot manager is now referenced from session_ ──
 
@@ -121,6 +123,7 @@ class GuiManager {
     GuiSnapshots gui_snapshots_;
     // ── MidiManager is now referenced from session_ ──
     GuiMidi gui_midi_;
+    GuiKeyboardShortcuts gui_keyboard_shortcuts_;
     AudioMetricsService metrics_service_;
 
     // ── Toast notification ──

--- a/src/gui/gui_manager_frame.cpp
+++ b/src/gui/gui_manager_frame.cpp
@@ -212,6 +212,24 @@ bool GuiManager::run_frame() {
                 recallSnapshotFromSlot(i);
             }
         }
+
+        // F1: toggle keyboard shortcuts modal
+        if (ImGui::IsKeyPressed(ImGuiKey_F1)) {
+            show_keyboard_shortcuts_ = !show_keyboard_shortcuts_;
+        }
+
+        // Ctrl+S: save preset
+        if (mod && !io.KeyShift && ImGui::IsKeyPressed(ImGuiKey_S)) {
+            gui_presets_.begin_save_preset();
+            show_save_preset_ = true;
+        }
+
+        // Ctrl+O: load preset
+        if (mod && !io.KeyShift && ImGui::IsKeyPressed(ImGuiKey_O)) {
+            show_load_preset_ = true;
+            gui_presets_.ensure_factory_presets();
+            gui_presets_.refresh_presets(true);
+        }
     }
 
     // ── Menu bar ──
@@ -284,6 +302,9 @@ bool GuiManager::run_frame() {
         }
     }
     if (show_midi_) gui_midi_.render(show_midi_);
+    if (show_keyboard_shortcuts_) {
+        gui_keyboard_shortcuts_.render(show_keyboard_shortcuts_);
+    }
 
     // ── Toast overlay ──
     if (toast_timer_ > 0.0f) {

--- a/src/gui/gui_manager_menu.cpp
+++ b/src/gui/gui_manager_menu.cpp
@@ -288,6 +288,12 @@ void GuiManager::render_menu_bar() {
             }
             ImGui::EndMenu();
         }
+        if (ImGui::BeginMenu("Help")) {
+            if (ImGui::MenuItem("Keyboard Shortcuts", "F1")) {
+                show_keyboard_shortcuts_ = true;
+            }
+            ImGui::EndMenu();
+        }
 
         // Status bar (right-aligned items computed dynamically)
         float bar_w = ImGui::GetWindowWidth();

--- a/src/gui/views/gui_keyboard_shortcuts.cpp
+++ b/src/gui/views/gui_keyboard_shortcuts.cpp
@@ -1,0 +1,78 @@
+#include "gui/views/gui_keyboard_shortcuts.h"
+
+#include <imgui.h>
+
+#include "gui/theme/theme.h"
+
+namespace Amplitron {
+
+void GuiKeyboardShortcuts::render(bool& show) {
+    if (!show) return;
+
+    ImGui::OpenPopup("Keyboard Shortcuts");
+
+    ImGui::SetNextWindowSize(ImVec2(450, 420), ImGuiCond_FirstUseEver);
+    bool open = show;
+    if (ImGui::BeginPopupModal("Keyboard Shortcuts", &open, ImGuiWindowFlags_NoResize)) {
+        ImGui::BeginChild("##ShortcutsScroll", ImVec2(0, -40), true);
+
+        if (ImGui::BeginTable("##ShortcutsTable", 2, ImGuiTableFlags_RowBg | ImGuiTableFlags_PadOuterX)) {
+            ImGui::TableSetupColumn("Action", ImGuiTableColumnFlags_WidthStretch);
+            ImGui::TableSetupColumn("Shortcut", ImGuiTableColumnFlags_WidthFixed, 180);
+
+            auto section_header = [](const char* name) {
+                ImGui::TableNextRow();
+                ImGui::TableNextColumn();
+                ImGui::Spacing();
+                ImGui::TextColored(Theme::Gold(), "%s", name);
+                ImGui::TableNextColumn();
+                ImGui::Spacing();
+            };
+
+            auto shortcut_row = [](const char* action, const char* keys) {
+                ImGui::TableNextRow();
+                ImGui::TableNextColumn();
+                ImGui::AlignTextToFramePadding();
+                ImGui::Text("%s", action);
+                ImGui::TableNextColumn();
+                ImGui::AlignTextToFramePadding();
+                ImGui::TextColored(Theme::TextSecondary(), "%s", keys);
+            };
+
+            section_header("General");
+            shortcut_row("Undo last action", "Ctrl+Z");
+            shortcut_row("Redo last action", "Ctrl+Shift+Z / Ctrl+Y");
+            shortcut_row("Toggle audio mute", "M");
+            shortcut_row("Show keyboard shortcuts", "F1");
+
+            section_header("Preset Management");
+            shortcut_row("Save preset", "Ctrl+S");
+            shortcut_row("Load preset", "Ctrl+O");
+
+            section_header("Snapshots");
+            shortcut_row("Recall Snapshot A", "Ctrl+1");
+            shortcut_row("Recall Snapshot B", "Ctrl+2");
+            shortcut_row("Recall Snapshot C", "Ctrl+3");
+            shortcut_row("Recall Snapshot D", "Ctrl+4");
+
+            section_header("Application");
+            shortcut_row("Quit", "Alt+F4");
+
+            ImGui::EndTable();
+        }
+
+        ImGui::EndChild();
+
+        ImGui::Spacing();
+        ImGui::SetCursorPosX(ImGui::GetWindowWidth() - 110);
+        if (ImGui::Button("Close", ImVec2(100, 25))) {
+            open = false;
+            ImGui::CloseCurrentPopup();
+        }
+
+        ImGui::EndPopup();
+    }
+    show = open;
+}
+
+}  // namespace Amplitron

--- a/src/gui/views/gui_keyboard_shortcuts.cpp
+++ b/src/gui/views/gui_keyboard_shortcuts.cpp
@@ -16,7 +16,8 @@ void GuiKeyboardShortcuts::render(bool& show) {
     if (ImGui::BeginPopupModal("Keyboard Shortcuts", &open, ImGuiWindowFlags_NoResize)) {
         ImGui::BeginChild("##ShortcutsScroll", ImVec2(0, -40), true);
 
-        if (ImGui::BeginTable("##ShortcutsTable", 2, ImGuiTableFlags_RowBg | ImGuiTableFlags_PadOuterX)) {
+        if (ImGui::BeginTable("##ShortcutsTable", 2,
+                              ImGuiTableFlags_RowBg | ImGuiTableFlags_PadOuterX)) {
             ImGui::TableSetupColumn("Action", ImGuiTableColumnFlags_WidthStretch);
             ImGui::TableSetupColumn("Shortcut", ImGuiTableColumnFlags_WidthFixed, 180);
 

--- a/src/gui/views/gui_keyboard_shortcuts.h
+++ b/src/gui/views/gui_keyboard_shortcuts.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "gui/ui_component.h"
+
+namespace Amplitron {
+
+struct KeyboardShortcutsProps {};
+
+/**
+ * @brief Modal dialog presenting the list of application keyboard shortcuts.
+ */
+class GuiKeyboardShortcuts : public UIComponent<KeyboardShortcutsProps> {
+   public:
+    GuiKeyboardShortcuts() = default;
+
+    /**
+     * @brief Render the shortcuts help modal.
+     * Uses the internal show_ flag — call render(show) for external visibility control.
+     */
+    void render() override { render(show_); }
+
+    /** @brief Render with an external show flag (GuiManager holds authoritative state). */
+    void render(bool& show);
+
+   private:
+    bool show_ = false;
+};
+
+}  // namespace Amplitron

--- a/tests/ui/test_gui_keyboard_shortcuts.cpp
+++ b/tests/ui/test_gui_keyboard_shortcuts.cpp
@@ -1,7 +1,4 @@
-/**
- * @file test_gui_keyboard_shortcuts.cpp
- * @brief Headless-safe tests for GuiKeyboardShortcuts.
- */
+#include <imgui_internal.h>
 #include <memory>
 
 #include "gui/views/gui_keyboard_shortcuts.h"
@@ -9,6 +6,31 @@
 #include "test_framework.h"
 
 using namespace Amplitron;
+
+static ImGuiID get_item_id(const char* window_substr, const char* item_id_str) {
+    ImGuiContext& g = *GImGui;
+    ImGuiID popup_id = ImGui::GetID(window_substr);
+    char popup_window_name[64];
+    snprintf(popup_window_name, sizeof(popup_window_name), "##Popup_%08x", popup_id);
+
+    for (int i = 0; i < g.Windows.Size; i++) {
+        if (strstr(g.Windows[i]->Name, window_substr) ||
+            strstr(g.Windows[i]->Name, popup_window_name)) {
+            return g.Windows[i]->GetID(item_id_str);
+        }
+    }
+    return 0;
+}
+
+static void click_item(const char* window_substr, const char* item_id_str) {
+    ImGuiID id = get_item_id(window_substr, item_id_str);
+    if (id != 0) {
+        ImGuiContext& g = *GImGui;
+        g.NavActivateId = id;
+        g.NavActivateDownId = id;
+        g.NavActivatePressedId = id;
+    }
+}
 
 TEST_F(PresetTest, gui_keyboard_shortcuts_construction_no_crash) {
     GuiKeyboardShortcuts gks;
@@ -41,4 +63,36 @@ TEST_F(PresetTest, gui_keyboard_shortcuts_render_visible) {
     ImGui::NewFrame();
 
     gks.render(show);
+}
+
+TEST_F(PresetTest, gui_keyboard_shortcuts_click_close_button) {
+    ScopedImGuiContext imgui;
+    GuiKeyboardShortcuts gks;
+
+    KeyboardShortcutsProps props;
+    gks.set_props(props);
+
+    bool show = true;
+    // Frame 1: open the popup modal
+    gks.render(show);
+
+    // End Frame 1 and start Frame 2
+    ImGui::Render();
+    ImGui::NewFrame();
+
+    // Render Frame 2: popup modal is now active and drawn
+    gks.render(show);
+
+    // End Frame 2 and start Frame 3
+    ImGui::Render();
+    ImGui::NewFrame();
+
+    // Click the Close button inside the "Keyboard Shortcuts" popup modal
+    click_item("Keyboard Shortcuts", "Close");
+
+    // Render Frame 3: process the click event and update the show flag
+    gks.render(show);
+
+    // The show flag should now be set to false after clicking Close
+    ASSERT_FALSE(show);
 }

--- a/tests/ui/test_gui_keyboard_shortcuts.cpp
+++ b/tests/ui/test_gui_keyboard_shortcuts.cpp
@@ -35,4 +35,10 @@ TEST_F(PresetTest, gui_keyboard_shortcuts_render_visible) {
 
     bool show = true;
     gks.render(show);
+
+    // End current frame and start a new one to allow popup modal to begin
+    ImGui::Render();
+    ImGui::NewFrame();
+
+    gks.render(show);
 }

--- a/tests/ui/test_gui_keyboard_shortcuts.cpp
+++ b/tests/ui/test_gui_keyboard_shortcuts.cpp
@@ -1,0 +1,38 @@
+/**
+ * @file test_gui_keyboard_shortcuts.cpp
+ * @brief Headless-safe tests for GuiKeyboardShortcuts.
+ */
+#include <memory>
+
+#include "gui/views/gui_keyboard_shortcuts.h"
+#include "test_fixtures.h"
+#include "test_framework.h"
+
+using namespace Amplitron;
+
+TEST_F(PresetTest, gui_keyboard_shortcuts_construction_no_crash) {
+    GuiKeyboardShortcuts gks;
+    (void)gks;
+}
+
+TEST_F(PresetTest, gui_keyboard_shortcuts_render_hidden) {
+    ScopedImGuiContext imgui;
+    GuiKeyboardShortcuts gks;
+
+    KeyboardShortcutsProps props;
+    gks.set_props(props);
+
+    bool show = false;
+    gks.render(show);
+}
+
+TEST_F(PresetTest, gui_keyboard_shortcuts_render_visible) {
+    ScopedImGuiContext imgui;
+    GuiKeyboardShortcuts gks;
+
+    KeyboardShortcutsProps props;
+    gks.set_props(props);
+
+    bool show = true;
+    gks.render(show);
+}

--- a/tests/ui/test_gui_keyboard_shortcuts.cpp
+++ b/tests/ui/test_gui_keyboard_shortcuts.cpp
@@ -1,4 +1,5 @@
 #include <imgui_internal.h>
+
 #include <memory>
 
 #include "gui/views/gui_keyboard_shortcuts.h"

--- a/tests/ui/test_gui_manager.cpp
+++ b/tests/ui/test_gui_manager.cpp
@@ -490,6 +490,14 @@ struct MockTunerWrapper {
     void set_props(const Amplitron::TunerProps& p) { real_tuner.set_props(p); }
 };
 
+struct MockKeyboardShortcutsWrapper {
+    Amplitron::GuiKeyboardShortcuts& real_shortcuts;
+    void render(bool& show) {
+        real_shortcuts.render(show);
+    }
+    void set_props(const Amplitron::KeyboardShortcutsProps& p) { real_shortcuts.set_props(p); }
+};
+
 #define GuiManager MockGuiManager
 #define ImGui mock_gui::MockImGui
 #define ImDrawList mock_gui::MockDrawList
@@ -507,6 +515,8 @@ struct MockTunerWrapper {
     MockPresetsWrapper { gui_presets_ }
 #define gui_tuner_ \
     MockTunerWrapper { gui_tuner_ }
+#define gui_keyboard_shortcuts_ \
+    MockKeyboardShortcutsWrapper { gui_keyboard_shortcuts_ }
 #include "gui/gui_manager_frame.cpp"
 #include "gui/gui_manager_menu.cpp"
 #undef GuiManager
@@ -524,6 +534,7 @@ struct MockTunerWrapper {
 #endif
 #undef gui_presets_
 #undef gui_tuner_
+#undef gui_keyboard_shortcuts_
 
 // UpdateChecker mocks
 static std::string mock_popen_result;
@@ -671,6 +682,9 @@ TEST(gui_manager_menu_bar_comprehensive_coverage) {
     gui.render_menu_bar();
     mock_gui::MockImGui::target_menu_item = "MIDI Settings";
     gui.render_menu_bar();
+    mock_gui::MockImGui::target_menu_item = "Keyboard Shortcuts";
+    gui.render_menu_bar();
+    ASSERT_TRUE(gui.show_keyboard_shortcuts_);
 
     // 13. Trigger MIDI status interactions
     mock_gui::MockImGui::target_menu_item = "MIDI";
@@ -726,6 +740,13 @@ TEST(gui_manager_frame_comprehensive_coverage) {
     mock_gui::MockImGui::target_key = ImGuiKey_1;
     mock_gui::MockImGui::GetIO().KeyCtrl = true;
     gui.run_frame();
+
+    // Keyboard shortcuts - Help Modal (F1)
+    gui.show_keyboard_shortcuts_ = false;
+    mock_gui::MockImGui::target_key = ImGuiKey_F1;
+    mock_gui::MockImGui::GetIO().KeyCtrl = false;
+    gui.run_frame();
+    ASSERT_TRUE(gui.show_keyboard_shortcuts_);
 
     // 3. Trigger showing popups
     gui.show_settings_ = true;

--- a/tests/ui/test_gui_manager.cpp
+++ b/tests/ui/test_gui_manager.cpp
@@ -492,9 +492,7 @@ struct MockTunerWrapper {
 
 struct MockKeyboardShortcutsWrapper {
     Amplitron::GuiKeyboardShortcuts& real_shortcuts;
-    void render(bool& show) {
-        real_shortcuts.render(show);
-    }
+    void render(bool& show) { real_shortcuts.render(show); }
     void set_props(const Amplitron::KeyboardShortcutsProps& p) { real_shortcuts.set_props(p); }
 };
 

--- a/tests/ui/test_gui_manager.cpp
+++ b/tests/ui/test_gui_manager.cpp
@@ -746,6 +746,22 @@ TEST(gui_manager_frame_comprehensive_coverage) {
     gui.run_frame();
     ASSERT_TRUE(gui.show_keyboard_shortcuts_);
 
+    // Keyboard shortcuts - Save Preset (Ctrl+S)
+    gui.show_save_preset_ = false;
+    mock_gui::MockImGui::target_key = ImGuiKey_S;
+    mock_gui::MockImGui::GetIO().KeyCtrl = true;
+    mock_gui::MockImGui::GetIO().KeyShift = false;
+    gui.run_frame();
+    ASSERT_TRUE(gui.show_save_preset_);
+
+    // Keyboard shortcuts - Load Preset (Ctrl+O)
+    gui.show_load_preset_ = false;
+    mock_gui::MockImGui::target_key = ImGuiKey_O;
+    mock_gui::MockImGui::GetIO().KeyCtrl = true;
+    mock_gui::MockImGui::GetIO().KeyShift = false;
+    gui.run_frame();
+    ASSERT_TRUE(gui.show_load_preset_);
+
     // 3. Trigger showing popups
     gui.show_settings_ = true;
     gui.show_save_preset_ = true;


### PR DESCRIPTION
Closes #348 


## What does this PR do?

Adds a dedicated, scrollable **Keyboard Shortcuts** help modal for Amplitron:
- Introduces a new "Help" menu dropdown in the top menu bar containing the "Keyboard Shortcuts" option.
- Implements the `GuiKeyboardShortcuts` UI component utilizing ImGui's Table API to list all shortcuts clearly organized by categories (General, Preset Management, Snapshots, Application).
- Integrates the `F1` key handler in `gui_manager_frame.cpp` to toggle the modal's visibility.
- Implements the missing keyboard event handlers for `Ctrl+S` (Save Preset) and `Ctrl+O` (Load Preset) so that they are fully functional application shortcuts.

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor / code cleanup
- [ ] 📝 Documentation
- [x] ✅ Tests
- [x] 🔧 Build / CI / Configuration

## How Was This Tested?

- Platform(s) tested on: Windows (UCRT64 GCC 13.2.0)
- Test command run: `./amplitron-tests` (or `C:/Users/RAKSHAK/amplitron_build/amplitron-tests.exe`)
- Manual test steps (if applicable):
  1. Open the application.
  2. Verify that clicking "Help > Keyboard Shortcuts" opens the help modal.
  3. Verify that pressing `F1` toggles the modal open and closed.
  4. Verify that pressing `Escape` or clicking "Close" closes the modal successfully.
  5. Verify that pressing `Ctrl+S` or `Ctrl+O` successfully triggers the save and load preset dialogs.

## Checklist

- [x] Code compiles and builds successfully on my platform
- [x] All existing tests pass (`./amplitron-tests`)
- [x] New tests added for new functionality (if applicable)
- [x] Documentation updated (README, code comments) if applicable
- [x] No blocking calls on the audio thread (no `std::mutex::lock()` on the hot path)
- [x] Tested on: Windows 11 (MSYS2 UCRT64 GCC)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Keyboard Shortcuts help dialog: modal, scrollable, two-column Action/Shortcut list grouped by category (General, Preset Management, Snapshots, Application).
  * Accessible via F1 or the Help menu; F1 toggles the dialog.
  * New keyboard shortcuts: Ctrl+S starts saving a preset; Ctrl+O opens preset loading.

* **Tests**
  * Added headless-safe tests covering the shortcuts dialog, menu item, and keyboard-triggered flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->