### PR TITLE
Fix duplicate error messages in add_link validation

### DIFF
--- a/src/audio/engine/audio_graph.cpp
+++ b/src/audio/engine/audio_graph.cpp
@@ -71,7 +71,7 @@ int AudioGraph::add_link(int source_pin_id, int dest_pin_id) {
             }
             if (out_count >= 1) {
                 printf("add_link failed: Output pin %d already has an outgoing connection!\n",
-                           source_pin_id);
+                        source_pin_id);
                 return -1;  // Each output pin can only have 1 outgoing connection!
             }
         }

--- a/src/audio/engine/audio_graph.cpp
+++ b/src/audio/engine/audio_graph.cpp
@@ -66,12 +66,12 @@ int AudioGraph::add_link(int source_pin_id, int dest_pin_id) {
             int out_count = 0;
             for (const auto &existing_link : links_) {
                 if (existing_link.source_pin_id == source_pin_id) {
-                    printf("add_link failed: Output pin %d already has an outgoing connection!\n",
-                           source_pin_id);
                     out_count++;
                 }
             }
             if (out_count >= 1) {
+                printf("add_link failed: Output pin %d already has an outgoing connection!\n",
+                           source_pin_id);
                 return -1;  // Each output pin can only have 1 outgoing connection!
             }
         }

--- a/src/audio/engine/audio_graph.cpp
+++ b/src/audio/engine/audio_graph.cpp
@@ -70,8 +70,9 @@ int AudioGraph::add_link(int source_pin_id, int dest_pin_id) {
                 }
             }
             if (out_count >= 1) {
-                printf("add_link failed: Output pin %d already has an outgoing connection!\n",
-                        source_pin_id);
+                printf(
+                    "add_link failed: Output pin %d already has an outgoing connection!\n",
+                    source_pin_id);
                 return -1;  // Each output pin can only have 1 outgoing connection!
             }
         }

--- a/src/audio/engine/audio_graph.cpp
+++ b/src/audio/engine/audio_graph.cpp
@@ -71,7 +71,8 @@ int AudioGraph::add_link(int source_pin_id, int dest_pin_id) {
             }
             if (out_count >= 1) {
                 printf(
-                    "add_link failed: Output pin %d already has an outgoing connection!\n",
+                    "add_link failed: Output pin %d already has an outgoing "
+                    "connection!\n",
                     source_pin_id);
                 return -1;  // Each output pin can only have 1 outgoing connection!
             }


### PR DESCRIPTION
## What does this PR do?

Fixes duplicate error messages in `AudioGraph::add_link()` by moving the error message outside the validation loop. This ensures the message is printed only once when an output pin already has an outgoing connection.

## Related Issue

Fixes #284

## Type of Change

* [x] 🐛 Bug fix
* [ ] ✨ New feature
* [ ] ♻️ Refactor / code cleanup
* [ ] 📝 Documentation
* [ ] ✅ Tests
* [ ] 🔧 Build / CI / Configuration

## How Was This Tested?

* Platform(s) tested on: Not Tested
* Test command run: Not run
* Manual test steps:

  * Reviewed the validation logic in `AudioGraph::add_link()`.
  * Verified that the error message is now emitted after the loop and therefore only once before returning `-1`.

## Checklist

* [ ] Code compiles and builds successfully on my platform
* [ ] All existing tests pass (`./amplitron-tests`)
* [ ] New tests added for new functionality (if applicable)
* [ ] Documentation updated (README, code comments) if applicable
* [ ] No blocking calls on the audio thread (not verified)
* [ ] Tested on: (not tested)

## Screenshots / Demo

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate “already has an outgoing connection” error output when adding multiple links from the same output pin by ensuring the message is shown only once per attempt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->