### PR TITLE
test: add missing JACK mock implementations to fix segfault

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -936,6 +936,8 @@ else() # NOT EMSCRIPTEN, ANDROID, or IOS
             "jack_activate=MOCK_jack_activate"
             "jack_deactivate=MOCK_jack_deactivate"
             "jack_port_get_buffer=MOCK_jack_port_get_buffer"
+            "jack_get_sample_rate=MOCK_jack_get_sample_rate"
+            "jack_get_buffer_size=MOCK_jack_get_buffer_size"
         )
     endif()
 

--- a/tests/fixtures/jack_mock.cpp
+++ b/tests/fixtures/jack_mock.cpp
@@ -71,6 +71,16 @@ int MOCK_jack_deactivate(jack_client_t *client) {
 }
 
 // Dummy buffers for input/output
+jack_nframes_t MOCK_jack_get_sample_rate(jack_client_t *client) {
+    (void)client;
+    return 48000;
+}
+
+jack_nframes_t MOCK_jack_get_buffer_size(jack_client_t *client) {
+    (void)client;
+    return 512;
+}
+
 static float s_dummy_in[4096] = {0.0f};
 static float s_dummy_out[4096] = {0.0f};
 

--- a/tests/fixtures/jack_mock.h
+++ b/tests/fixtures/jack_mock.h
@@ -28,5 +28,7 @@ int MOCK_jack_set_process_callback(jack_client_t *client,
 int MOCK_jack_activate(jack_client_t *client);
 int MOCK_jack_deactivate(jack_client_t *client);
 void *MOCK_jack_port_get_buffer(jack_port_t *port, jack_nframes_t nframes);
+jack_nframes_t MOCK_jack_get_sample_rate(jack_client_t *client);
+jack_nframes_t MOCK_jack_get_buffer_size(jack_client_t *client);
 }
 #endif


### PR DESCRIPTION
## What does this PR do?

This PR fixes a segmentation fault occurring in the `amplitron-tests` suite when compiled with JACK support on Linux.

The crash was caused by incomplete JACK mocking. While several JACK functions were already redirected to mock implementations, `jack_get_sample_rate` and `jack_get_buffer_size` were missing from the mock layer. As a result, these calls fell back to the real `libjack.so`, which received a fake `jack_client_t` pointer (`0x12345678`) from the test environment, leading to a segmentation fault.

This PR completes the JACK mock coverage to fully isolate the test environment from the system audio backend.

---

## Related Issue

Fixes #374

---

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor / code cleanup
- [ ] 📝 Documentation
- [x] ✅ Tests
- [ ] 🔧 Build / CI / Configuration

---

## How Was This Tested?

- **Platform(s) tested on:** Linux (Arch Linux, kernel 6.x)

- **Test command run:**
  ```bash
  rm -rf build/
  cmake -B build
  cmake --build build
  ./build/amplitron-tests

## Checklist

- [x] Code compiles and builds successfully on my platform
- [x] All existing tests pass (`./amplitron-tests`)
- [ ] New tests added for new functionality (if applicable)
- [ ] Documentation updated (README, code comments) if applicable
- [x] No blocking calls on the audio thread (no `std::mutex::lock()` on the hot path)
- [x] Tested on: (list your OS/platform)

## Screenshots / Demo
<img width="460" height="105" alt="image" src="https://github.com/user-attachments/assets/0de63119-15b6-4457-a6fe-47c764a0669c" />

<!-- Add screenshots or GIFs if this changes the UI -->
