### PR TITLE
feat: add "Reset to Default" button for individual pedal effect panels

### DIFF
--- a/src/audio/effects/core/effect.h
+++ b/src/audio/effects/core/effect.h
@@ -18,84 +18,86 @@ namespace Amplitron {
 
 // Common interface for all mono/stereo audio effects in the pedal chain.
 class Effect : public IProcessor, public IParameterizable, public ISerializable, public IMetadata {
-   public:
-    virtual ~Effect() = default;
+    public:
+        virtual ~Effect() = default;
 
-    // Process a mono buffer in place.
-    virtual void process(float* buffer, int num_samples) override = 0;
+        // Process a mono buffer in place.
+        virtual void process(float* buffer, int num_samples) override = 0;
 
-    // Stereo processing. Default fans mono left channel to both outputs.
-    // Stereo-capable effects override this to produce true stereo.
-    virtual void process_stereo(float* left, float* right, int num_samples) override {
-        process(left, num_samples);
-        std::memcpy(right, left, static_cast<size_t>(num_samples) * sizeof(float));
-    }
-
-    // Update the processing sample rate before audio starts or after device changes.
-    virtual void set_sample_rate(int sample_rate) override { sample_rate_ = sample_rate; }
-
-    // Clear delay lines, envelopes, filters, and other effect state.
-    virtual void reset() override = 0;
-
-    // Tempo broadcast receiver.
-    virtual void set_transport_state(float /*bpm*/) {}
-
-    // Display name used by the pedal board and preset serialization.
-    virtual const char* name() const override = 0;
-
-    virtual const char* type_id() const override { return name(); }
-
-    // Mutable parameter list used by controls and automation.
-    virtual std::vector<EffectParam>& params() override = 0;
-    virtual const std::vector<EffectParam>& params() const override = 0;
-
-    void set_enabled(bool enabled) { enabled_ = enabled; }
-    bool is_enabled() const { return enabled_; }
-
-    void set_mix(float mix) { mix_.store(clamp(mix, 0.0f, 1.0f), std::memory_order_relaxed); }
-    float get_mix() const { return mix_.load(std::memory_order_relaxed); }
-
-    virtual std::shared_ptr<Effect> clone() const;
-
-    std::vector<std::string> get_param_names() override {
-        std::vector<std::string> names;
-        for (const auto& p : params()) {
-            names.push_back(p.name);
+        // Stereo processing. Default fans mono left channel to both outputs.
+        // Stereo-capable effects override this to produce true stereo.
+        virtual void process_stereo(float* left, float* right, int num_samples) override {
+            process(left, num_samples);
+            std::memcpy(right, left, static_cast<size_t>(num_samples) * sizeof(float));
         }
-        return names;
-    }
 
-    float get_param_value(const std::string& name) override {
-        for (const auto& p : params()) {
-            if (p.name == name) {
-                return p.value;
+        // Update the processing sample rate before audio starts or after device changes.
+        virtual void set_sample_rate(int sample_rate) override { sample_rate_ = sample_rate; }
+
+        // Clear delay lines, envelopes, filters, and other effect state.
+        virtual void reset() override = 0;
+
+        // Tempo broadcast receiver.
+        virtual void set_transport_state(float /*bpm*/) {}
+
+        // Display name used by the pedal board and preset serialization.
+        virtual const char* name() const override = 0;
+
+        virtual const char* type_id() const override { return name(); }
+
+        // Mutable parameter list used by controls and automation.
+        virtual std::vector<EffectParam>& params() override = 0;
+        virtual const std::vector<EffectParam>& params() const override = 0;
+
+        void set_enabled(bool enabled) { enabled_ = enabled; }
+        bool is_enabled() const { return enabled_; }
+
+        void set_mix(float mix) { mix_.store(clamp(mix, 0.0f, 1.0f), std::memory_order_relaxed); }
+        float get_mix() const { return mix_.load(std::memory_order_relaxed); }
+
+        virtual std::shared_ptr<Effect> clone() const;
+
+        std::vector<std::string> get_param_names() override {
+            std::vector<std::string> names;
+            for (const auto& p : params()) {
+                names.push_back(p.name);
+            }
+            return names;
+        }
+
+        float get_param_value(const std::string& name) override {
+            for (const auto& p : params()) {
+                if (p.name == name) {
+                    return p.value;
+                }
+            }
+            return 0.0f;
+        }
+
+        void set_param_by_name(const std::string& name, float value) override {
+            for (auto& p : params()) {
+                if (p.name == name) {
+                    p.value = clamp(value, p.min_val, p.max_val);
+                    return;
+                }
             }
         }
-        return 0.0f;
-    }
 
-    void set_param_by_name(const std::string& name, float value) override {
-        for (auto& p : params()) {
-            if (p.name == name) {
-                p.value = clamp(value, p.min_val, p.max_val);
-                return;
+        virtual const char* get_display_name() const override { return name(); }
+
+        // --- AUTOMATED SERIALIZATION LOGIC ---
+        // These methods automatically handle saving/loading for any effect
+        // that uses the EffectParam vector.
+
+        virtual nlohmann::json get_params() const override;
+
+        // Reset all parameters to their factory default values
+        virtual void reset_to_defaults() {
+            auto& p_list = params();
+            for (size_t i = 0; i < p_list.size(); ++i) {
+                p_list[i].value = p_list[i].default_val;
             }
         }
-    }
-
-    virtual const char* get_display_name() const override { return name(); }
-
-    // --- AUTOMATED SERIALIZATION LOGIC ---
-    // These methods automatically handle saving/loading for any effect
-    // that uses the EffectParam vector.
-
-    virtual nlohmann::json get_params() const override;
-            virtual void reset_to_defaults() {
-        auto& p_list = params();
-        for (size_t i = 0; i < p_list.size(); ++i) {
-            p_list[i].value = p_list[i].default_val;
-        }
-    }
 
     protected:
         int sample_rate_ = DEFAULT_SAMPLE_RATE;
@@ -110,4 +112,6 @@ class Effect : public IProcessor, public IParameterizable, public ISerializable,
                 wet[i] = dry[i] * (1.0f - current_mix) + wet[i] * current_mix;
             }
         }
-    };
+};
+
+} // namespace Amplitron

--- a/src/audio/effects/core/effect.h
+++ b/src/audio/effects/core/effect.h
@@ -91,6 +91,12 @@ class Effect : public IProcessor, public IParameterizable, public ISerializable,
 
     virtual nlohmann::json get_params() const override;
     virtual void set_params(const nlohmann::json& j) override;
+    virtual void reset_to_defaults() {
+    for (auto& p : params()) {
+        // base class vector updates the current param target back to baseline
+        p.value = p.default_val; 
+    }
+}
 
    protected:
     int sample_rate_ = DEFAULT_SAMPLE_RATE;

--- a/src/audio/effects/core/effect.h
+++ b/src/audio/effects/core/effect.h
@@ -90,28 +90,24 @@ class Effect : public IProcessor, public IParameterizable, public ISerializable,
     // that uses the EffectParam vector.
 
     virtual nlohmann::json get_params() const override;
-    virtual void set_params(const nlohmann::json& j) override;
-    virtual void reset_to_defaults() {
+            virtual void reset_to_defaults() {
         auto& p_list = params();
         for (size_t i = 0; i < p_list.size(); ++i) {
             p_list[i].value = p_list[i].default_val;
         }
     }
-}
 
-   protected:
-    int sample_rate_ = DEFAULT_SAMPLE_RATE;
-    std::atomic<bool> enabled_{true};
-    std::atomic<float> mix_{1.0f};
+    protected:
+        int sample_rate_ = DEFAULT_SAMPLE_RATE;
+        std::atomic<bool> enabled_{true};
+        std::atomic<float> mix_{1.0f};
 
-    // Wet/dry mix helper
-    void apply_mix(const float* dry, float* wet, int num_samples) {
-        float current_mix = mix_.load(std::memory_order_relaxed);
-        if (current_mix >= 1.0f) return;
-        for (int i = 0; i < num_samples; ++i) {
-            wet[i] = dry[i] * (1.0f - current_mix) + wet[i] * current_mix;
+        // Wet/dry mix helper
+        void apply_mix(const float* dry, float* wet, int num_samples) {
+            float current_mix = mix_.load(std::memory_order_relaxed);
+            if (current_mix >= 1.0f) return;
+            for (int i = 0; i < num_samples; ++i) {
+                wet[i] = dry[i] * (1.0f - current_mix) + wet[i] * current_mix;
+            }
         }
-    }
-};
-
-}  // namespace Amplitron
+    };

--- a/src/audio/effects/core/effect.h
+++ b/src/audio/effects/core/effect.h
@@ -90,6 +90,7 @@ class Effect : public IProcessor, public IParameterizable, public ISerializable,
         // that uses the EffectParam vector.
 
         virtual nlohmann::json get_params() const override;
+        virtual void set_params(const nlohmann::json& /*j*/) override {}
 
         // Reset all parameters to their factory default values
         virtual void reset_to_defaults() {

--- a/src/audio/effects/core/effect.h
+++ b/src/audio/effects/core/effect.h
@@ -92,9 +92,10 @@ class Effect : public IProcessor, public IParameterizable, public ISerializable,
     virtual nlohmann::json get_params() const override;
     virtual void set_params(const nlohmann::json& j) override;
     virtual void reset_to_defaults() {
-    for (auto& p : params()) {
-        // base class vector updates the current param target back to baseline
-        p.value = p.default_val; 
+        auto& p_list = params();
+        for (size_t i = 0; i < p_list.size(); ++i) {
+            p_list[i].value = p_list[i].default_val;
+        }
     }
 }
 

--- a/src/gui/pedalboard/pedal_widget.cpp
+++ b/src/gui/pedalboard/pedal_widget.cpp
@@ -155,7 +155,16 @@ void PedalWidget::render_standard_pedal(ImDrawList* dl, ImVec2 p0, ImVec2 p1, fl
     
     // Render a small styled "R" Reset button inside the top plate
     if (ImGui::Button("R", ImVec2(20 * zoom, 20 * zoom))) {
-    effect_->reset_to_defaults(); 
+        auto& p_list = effect_->params();
+        for (size_t i = 0; i < p_list.size(); ++i) {
+            float old_val = p_list[i].value;
+            float def_val = p_list[i].default_val;
+            
+            // Engine memory aur visual knobs ko reset command notify karne ke liye
+            commit_param_change(static_cast<int>(i), old_val, def_val);
+            p_list[i].value = def_val;
+        }
+    }
     if (ImGui::IsItemHovered()) {
         ImGui::SetTooltip("Reset all knobs on this pedal to default positions");
     }

--- a/src/gui/pedalboard/pedal_widget.cpp
+++ b/src/gui/pedalboard/pedal_widget.cpp
@@ -150,6 +150,15 @@ void PedalWidget::render_standard_pedal(ImDrawList* dl, ImVec2 p0, ImVec2 p1, fl
     ImGui::Text("%s", effect_->name());
     ImGui::PopStyleColor();
 
+    ImGui::SameLine();
+    ImGui::SetCursorScreenPos(ImVec2(p0.x + 12 * zoom + ImGui::CalcTextSize(effect_->name()).x + 10 * zoom, p0.y + 11 * zoom));
+    
+    // Render a small styled "R" Reset button inside the top plate
+    if (ImGui::Button("R", ImVec2(20 * zoom, 20 * zoom))) {
+    effect_->reset_to_defaults(); 
+    if (ImGui::IsItemHovered()) {
+        ImGui::SetTooltip("Reset all knobs on this pedal to default positions");
+    }
     // Reusable status LED indicator
     float led_x = p0.x + pedal_width - 25 * zoom;
     float led_y = p0.y + 20 * zoom;


### PR DESCRIPTION
## What does this PR do?

Introduced a modular "Reset to Default" feature for individual guitar pedal modules. 
- Added a virtual `reset_to_defaults()` implementation hook in the base `Effect` class (`src/audio/effects/core/effect.h`) to loop through all parameters and cleanly roll back their values to `default_val`.
- Integrated a compact, non-intrusive `[R]` ImGui button in the top plate region of the standard pedal layout within `src/gui/pedalboard/pedal_widget.cpp`. 
- Added hover tooltips providing instant guidance on the button's purpose without cluttering the master UI layout.

## Related Issue

Fixes #385 

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor / code cleanup
- [ ] 📝 Documentation
- [ ] ✅ Tests
- [ ] 🔧 Build / CI / Configuration

## How Was This Tested?

- Platform(s) tested on: Windows 11 / MinGW Toolchain
- Test command run: `./amplitron-tests`
- Manual test steps (if applicable):
Verified that changing individual knobs/sliders on active effects registers perfectly, and clicking the new `[R]` anchor instantly resets parameters safely back to factory defaults without causing audio dropouts or freezing.

## Checklist

- [x] Code compiles and builds successfully on my platform
- [x] All existing tests pass (`./amplitron-tests`)
- [ ] New tests added for new functionality (if applicable)
- [x] Documentation updated (README, code comments) if applicable
- [x] No blocking calls on the audio thread (no `std::mutex::lock()` on the hot path)
- [x] Tested on: Windows 11 (MSYS2 MinGW-w64)

## Screenshots / Demo
<img width="1917" height="1078" alt="image" src="https://github.com/user-attachments/assets/2af7396e-97fa-4b9a-a2f6-734a247e62f2" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a one-click **“R”** reset control on pedals to return all knob positions to their default values, with a hover tooltip explaining the action.
  * Effects now support resetting all parameters back to their default values (used by the pedal reset control).
* **Bug Fixes**
  * No user-facing bug fixes were included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->