### PR TITLE
feat(audio): add real-time DSP performance profiler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -680,25 +680,17 @@ jobs:
           cmake --build sdl2-build -j$(sysctl -n hw.ncpu)
           cmake --install sdl2-build
 
-      - name: Cache CMake configure output
-        id: cmake-cache
-        uses: actions/cache@v5
-        with:
-          path: build-ios
-          key: ios-cmake-${{ runner.os }}-${{ hashFiles('CMakeLists.txt', 'ios/Info.plist', '.github/workflows/ci.yml') }}
-          restore-keys: |
-            ios-cmake-${{ runner.os }}-
-
       - name: Configure
-        if: steps.cmake-cache.outputs.cache-hit != 'true'
         run: |
+          rm -rf build-ios
           cmake \
             -DCMAKE_SYSTEM_NAME=iOS \
             -DCMAKE_OSX_DEPLOYMENT_TARGET=15.0 \
             -DCMAKE_OSX_ARCHITECTURES="arm64" \
             -DAMPLITRON_VERSION="${{ steps.version.outputs.version }}" \
-            -DSDL2_INCLUDE_DIRS=$HOME/sdl2-ios/include/SDL2 \
+            -DSDL2_INCLUDE_DIRS="$HOME/sdl2-ios/include;$HOME/sdl2-ios/include/SDL2" \
             -DSDL2_LIBRARIES="$HOME/sdl2-ios/lib/libSDL2main.a;$HOME/sdl2-ios/lib/libSDL2.a" \
+            -DCMAKE_EXE_LINKER_FLAGS="-framework QuartzCore -framework CoreGraphics -framework CoreBluetooth -framework Metal" \
             -G Xcode \
             -S . -B build-ios
 
@@ -715,6 +707,8 @@ jobs:
       - name: Build iOS Device
         run: |
           set -o pipefail
+          set +e
+
           xcodebuild \
             -project build-ios/Amplitron.xcodeproj \
             -scheme Amplitron \
@@ -722,9 +716,17 @@ jobs:
             -sdk iphoneos \
             ONLY_ACTIVE_ARCH=YES \
             CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO \
-            build 2>&1 | tee /tmp/xcode.log | xcpretty --color; \
-          STATUS=${PIPESTATUS[0]}; \
-          [ $STATUS -eq 0 ] || { echo "=== FULL XCODE LOG ==="; cat /tmp/xcode.log; exit $STATUS; }
+            build 2>&1 | tee /tmp/xcode.log | xcpretty --color
+
+          STATUS=${PIPESTATUS[0]}
+          set -e
+
+          if [ "$STATUS" -ne 0 ]; then
+            echo "=== FULL XCODE LOG ==="
+            cat /tmp/xcode.log
+            exit "$STATUS"
+          fi
+
 
       - name: Validate .app bundle
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,6 +254,7 @@ set(APP_SOURCES
     src/audio/engine/audio_engine.cpp
     src/audio/engine/audio_engine_chain.cpp
     src/audio/engine/audio_engine_process.cpp
+    src/audio/engine/dsp_performance_profiler.cpp
     src/audio/engine/audio_engine_api.cpp
     src/audio/engine/audio_metrics_service.cpp
     src/audio/engine/metronome.cpp
@@ -296,6 +297,7 @@ set(APP_SOURCES
     src/gui/views/gui_tuner.cpp
     src/gui/views/gui_keyboard_shortcuts.cpp
     src/gui/views/gui_analyzer.cpp
+    src/gui/views/gui_dsp_profiler.cpp
     src/gui/pedalboard/pedal_board.cpp
     src/gui/pedalboard/pedal_board_menu.cpp
     src/gui/pedalboard/pedal_board_chain.cpp
@@ -604,6 +606,7 @@ else() # NOT EMSCRIPTEN, ANDROID, or IOS
         # Audio engine (partial — see exclusion note above)
         src/audio/engine/audio_engine_chain.cpp
         src/audio/engine/audio_engine_process.cpp
+        src/audio/engine/dsp_performance_profiler.cpp
         src/audio/engine/audio_engine_api.cpp
         src/audio/engine/audio_metrics_service.cpp
         src/audio/engine/metronome.cpp
@@ -751,6 +754,7 @@ else() # NOT EMSCRIPTEN, ANDROID, or IOS
         tests/unit/test_audio_backend_registry.cpp
         tests/unit/test_audio_backend_sdl.cpp
         tests/unit/test_audio_metrics_service.cpp
+        tests/unit/test_dsp_performance_profiler.cpp
         tests/unit/test_audio_command_dispatcher.cpp
         tests/unit/test_oboe_ring_buffer.cpp
         tests/unit/test_effects_dynamics.cpp
@@ -842,6 +846,7 @@ else() # NOT EMSCRIPTEN, ANDROID, or IOS
         src/gui/views/gui_tuner.cpp
         src/gui/views/gui_keyboard_shortcuts.cpp
         src/gui/views/gui_analyzer.cpp
+        src/gui/views/gui_dsp_profiler.cpp
         src/gui/pedalboard/pedal_board.cpp
         src/gui/pedalboard/pedal_board_menu.cpp
         src/gui/pedalboard/pedal_board_chain.cpp

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Transform your computer into a complete guitar rig. Plug in your guitar via USB 
 - **Sample rates** — 44.1kHz, 48kHz, 96kHz
 - **Auto-detection of USB guitar cables** — automatically selects USB input device for guitar, laptop output for speakers
 - **Real-time input/output metering**
+- **Real-time DSP performance profiling** — tracks latency, callback budget, CPU load, deadline misses, underruns/overruns, and per-module DSP timing
 - **Adjustable input and output gain**
 - **Device selection** — choose any PortAudio-compatible input/output device, with USB devices highlighted in the UI
 
@@ -115,9 +116,10 @@ Transform your computer into a complete guitar rig. Plug in your guitar via USB 
 
 ### Utilities
 
-| Tool                | Description                                                                   |
-| ------------------- | ----------------------------------------------------------------------------- |
-| **Chromatic Tuner** | YIN pitch detection algorithm with note name, octave, and cent offset display |
+| Tool                         | Description                                                                                                  |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| **Chromatic Tuner**          | YIN pitch detection algorithm with note name, octave, and cent offset display                                |
+| **DSP Performance Profiler** | Real-time latency, CPU budget, underrun/overrun, history graph, and per-DSP-module processing-time visibility |
 
 ### Visual Pedal Board
 

--- a/docs/dsp-performance-profiler.md
+++ b/docs/dsp-performance-profiler.md
@@ -1,0 +1,99 @@
+# DSP Performance Profiler
+
+The DSP Performance Profiler provides real-time visibility into Amplitron's audio processing health. It helps users and developers understand whether the audio callback is staying within its real-time processing budget and which DSP modules are consuming the most processing time.
+
+## What it tracks
+
+- Sample rate and buffer size
+- Estimated audio latency in milliseconds
+- Audio callback budget in microseconds
+- Last callback processing time
+- CPU load as a percentage of the real-time callback budget
+- Callback deadline misses
+- Stream underrun and overrun counters
+- Per-DSP-module processing time
+- Per-module average, peak, and budget percentage
+- Latency and CPU history graphs
+
+## User interface
+
+Open the profiler from:
+
+```text
+Utilities -> DSP Performance Profiler
+```
+
+The panel shows a real-time overview of audio callback health, processing history, and per-node DSP timing.
+
+## Warning thresholds
+
+The profiler reports:
+
+- `OK` when the callback is comfortably within budget
+- `WARNING` when CPU load reaches 80% of the real-time callback budget
+- `CRITICAL` when CPU load reaches or exceeds 100%
+- `OVERLOADED` for DSP modules consuming 25% or more of the callback budget
+
+Warnings are displayed as explicit text and table status labels, not color alone.
+
+## Real-time safety
+
+The profiler is designed for use from the audio callback path.
+
+The audio-thread instrumentation avoids:
+
+- heap allocation
+- file I/O
+- logging
+- mutex locking
+- command queue changes
+- graph topology changes
+
+Callback and module metrics are stored using atomics and fixed-size history buffers.
+
+## Backend stream health
+
+The profiler records stream health events from supported backends:
+
+- PortAudio callback status flags for input/output underflow and overflow
+- SDL capture queue monitoring for underrun and overrun conditions
+
+These counters help identify glitches caused by audio-device starvation, delayed capture input, or overloaded processing.
+
+## Developer notes
+
+The profiler is implemented in:
+
+```text
+src/audio/engine/dsp_performance_profiler.h
+src/audio/engine/dsp_performance_profiler.cpp
+src/gui/views/gui_dsp_profiler.h
+src/gui/views/gui_dsp_profiler.cpp
+```
+
+Main integration points:
+
+```text
+src/audio/engine/audio_engine_process.cpp
+src/audio/engine/audio_graph_executor.cpp
+src/audio/backend/portaudio_backend.cpp
+src/audio/backend/sdl_backend.cpp
+src/gui/gui_manager_menu.cpp
+src/gui/gui_manager_frame.cpp
+```
+
+## Validation
+
+Recommended local validation:
+
+```bash
+cmake --build build --target Amplitron --parallel
+```
+
+Then run the application and open:
+
+```text
+Utilities -> DSP Performance Profiler
+```
+
+Confirm that the panel displays latency, CPU load, history graphs, per-module timings, and stream health counters.

--- a/src/audio/backend/portaudio_backend.cpp
+++ b/src/audio/backend/portaudio_backend.cpp
@@ -96,8 +96,24 @@ bool devices_share_host_api(int input_dev, int output_dev) {
 // Real callback implementation
 int pa_audio_callback(const void* input, void* output, unsigned long frame_count,
                       const PaStreamCallbackTimeInfo* /*time_info*/,
-                      PaStreamCallbackFlags /*status_flags*/, void* user_data) {
+                      PaStreamCallbackFlags status_flags, void* user_data) {
     auto* engine = static_cast<IAudioEngine*>(user_data);
+
+    if (!engine) {
+        if (output) {
+            std::memset(output, 0, frame_count * 2 * sizeof(float));
+        }
+        return paContinue;
+    }
+
+    if ((status_flags & paInputUnderflow) || (status_flags & paOutputUnderflow)) {
+        engine->record_profiler_underrun();
+    }
+
+    if ((status_flags & paInputOverflow) || (status_flags & paOutputOverflow)) {
+        engine->record_profiler_overrun();
+    }
+
     const auto* in = static_cast<const float*>(input);
     auto* out = static_cast<float*>(output);
 

--- a/src/audio/backend/sdl_backend.cpp
+++ b/src/audio/backend/sdl_backend.cpp
@@ -26,11 +26,16 @@ void sdl_audio_callback(void* userdata, Uint8* stream, int len) {
     }
 
     SDL_AudioDeviceID cap_dev = be->get_capture_device();
+
     if (cap_dev != 0) {
         Uint32 queued = SDL_GetQueuedAudioSize(cap_dev);
         Uint32 need = static_cast<Uint32>(frame_count * sizeof(float));
-
         Uint32 max_queued = need * 2;
+
+        if (queued > max_queued) {
+            engine->record_profiler_overrun();
+        }
+
         while (queued > max_queued) {
             Uint8 junk[4096];
             Uint32 chunk = (queued - need) > 4096 ? 4096 : (queued - need);
@@ -40,9 +45,12 @@ void sdl_audio_callback(void* userdata, Uint8* stream, int len) {
 
         Uint32 got = SDL_DequeueAudio(cap_dev, cap.data(), need);
         int captured = static_cast<int>(got / sizeof(float));
-        if (captured < frame_count)
+
+        if (captured < frame_count) {
+            engine->record_profiler_underrun();
             std::memset(cap.data() + captured, 0,
                         static_cast<size_t>(frame_count - captured) * sizeof(float));
+        }
     } else {
         std::memset(cap.data(), 0, static_cast<size_t>(frame_count) * sizeof(float));
     }
@@ -51,6 +59,7 @@ void sdl_audio_callback(void* userdata, Uint8* stream, int len) {
 }
 
 SdlBackend::SdlBackend() = default;
+
 SdlBackend::~SdlBackend() { shutdown(); }
 
 bool SdlBackend::initialize(IAudioEngine* engine) {
@@ -88,6 +97,7 @@ bool SdlBackend::start() {
         target_buffer = p;
     }
 #endif
+
     int target_rate = engine_->get_sample_rate();
 
     SDL_AudioSpec want_out, have_out;
@@ -128,15 +138,18 @@ bool SdlBackend::start() {
     for (int i = 0; i < num_capture; ++i) {
         const char* name = SDL_GetAudioDeviceName(i, 1);
         if (!name) continue;
+
         std::string lower = name;
         std::transform(lower.begin(), lower.end(), lower.begin(),
                        [](unsigned char c) { return std::tolower(c); });
+
         for (const auto* kw : usb_keywords) {
             if (lower.find(kw) != std::string::npos) {
                 preferred_device = name;
                 break;
             }
         }
+
         if (preferred_device) break;
     }
 
@@ -158,10 +171,12 @@ void SdlBackend::stop() {
         if (capture_device_ != 0) SDL_PauseAudioDevice(capture_device_, 1);
         running_ = false;
     }
+
     if (capture_device_ != 0) {
         SDL_CloseAudioDevice(capture_device_);
         capture_device_ = 0;
     }
+
     if (audio_device_ != 0) {
         SDL_CloseAudioDevice(audio_device_);
         audio_device_ = 0;

--- a/src/audio/engine/audio_engine.h
+++ b/src/audio/engine/audio_engine.h
@@ -9,6 +9,7 @@
 #include "audio/engine/audio_command_dispatcher.h"
 #include "audio/engine/audio_graph.h"
 #include "audio/engine/audio_graph_executor.h"
+#include "audio/engine/dsp_performance_profiler.h"
 #include "audio/engine/i_audio_engine.h"
 #include "audio/engine/i_metronome.h"
 #include "audio/engine/metronome.h"
@@ -287,6 +288,16 @@ class AudioEngine : public IAudioEngine {
     /** @brief Return the current CPU load fraction (0.0–1.0, atomic). */
     float get_cpu_load() const override { return cpu_load_.load(std::memory_order_relaxed); }
 
+    DspProfilerSnapshot get_dsp_profiler_snapshot() const override {
+        return dsp_profiler_.snapshot();
+    }
+
+    void reset_dsp_profiler() override { dsp_profiler_.reset(); }
+
+    void record_profiler_underrun() override { dsp_profiler_.record_underrun(); }
+
+    void record_profiler_overrun() override { dsp_profiler_.record_overrun(); }
+
     /** @brief Suggest a new buffer size based on current CPU load. */
     int get_suggested_buffer_size() const override;
 
@@ -374,6 +385,7 @@ class AudioEngine : public IAudioEngine {
     // CPU load watchdog for buffer auto-tuning
     std::atomic<float> cpu_load_{0.0f};
     std::atomic<float> callback_duration_us_{0.0f};
+    DspPerformanceProfiler dsp_profiler_;
     bool auto_buffer_enabled_ = false;
 
     std::unique_ptr<AnalyzerCapture> analyzer_capture_;

--- a/src/audio/engine/audio_engine_process.cpp
+++ b/src/audio/engine/audio_engine_process.cpp
@@ -11,6 +11,7 @@ namespace Amplitron {
 
 void AudioEngine::process_audio(const float* input, float* output, int frame_count) {
     auto t_start = std::chrono::steady_clock::now();
+    dsp_profiler_.begin_callback(frame_count, sample_rate_, buffer_size_);
 
     if (frame_count > static_cast<int>(process_buffer_.size())) {
         process_buffer_.resize(frame_count, 0.0f);
@@ -71,7 +72,7 @@ void AudioEngine::process_audio(const float* input, float* output, int frame_cou
 
         // Pass your mono/stereo buffers to the executor we built
         audio_shadow_executor_->process(process_buffer_.data(), process_buffer_right_.data(),
-                                        frame_count);
+                                        frame_count, &dsp_profiler_);
         std::memcpy(process_buffer_.data(), process_buffer_right_.data(),
                     static_cast<size_t>(frame_count) * sizeof(float));
     }
@@ -119,9 +120,17 @@ void AudioEngine::process_audio(const float* input, float* output, int frame_cou
 
     auto t_end = std::chrono::steady_clock::now();
     float duration_us = std::chrono::duration<float, std::micro>(t_end - t_start).count();
+
     callback_duration_us_.store(duration_us, std::memory_order_relaxed);
-    float budget_us = (static_cast<float>(frame_count) / sample_rate_) * 1e6f;
-    cpu_load_.store(duration_us / budget_us, std::memory_order_relaxed);
+
+    const float budget_us =
+        sample_rate_ > 0
+            ? (static_cast<float>(frame_count) / static_cast<float>(sample_rate_)) * 1e6f
+            : 0.0f;
+
+    cpu_load_.store(budget_us > 0.0f ? duration_us / budget_us : 0.0f, std::memory_order_relaxed);
+
+    dsp_profiler_.end_callback(duration_us);
 }
 
 }  // namespace Amplitron

--- a/src/audio/engine/audio_graph_executor.cpp
+++ b/src/audio/engine/audio_graph_executor.cpp
@@ -1,6 +1,7 @@
 #include "audio/engine/audio_graph_executor.h"
 
 #include <algorithm>
+#include <chrono>
 #include <cstring>
 
 namespace Amplitron {
@@ -116,7 +117,8 @@ void AudioGraphExecutor::update_transport_state(float bpm) {
     }
 }
 
-void AudioGraphExecutor::process(const float* input, float* output, int num_samples) {
+void AudioGraphExecutor::process(const float* input, float* output, int num_samples,
+                                 DspPerformanceProfiler* profiler) {
     if (num_samples > max_block_size_) {
         std::memset(output, 0, static_cast<size_t>(num_samples) * sizeof(float));
         return;
@@ -126,7 +128,8 @@ void AudioGraphExecutor::process(const float* input, float* output, int num_samp
         return;
     }
 
-    for (const auto& step : execution_plan_) {
+    for (size_t step_index = 0; step_index < execution_plan_.size(); ++step_index) {
+        const auto& step = execution_plan_[step_index];
         float* node_input = sum_buffer_.data();
 
         bool is_input_source = false;
@@ -158,10 +161,21 @@ void AudioGraphExecutor::process(const float* input, float* output, int num_samp
 
         float* node_output = buffer_pool_[step.buffer_index].data();
 
+        const auto module_start = std::chrono::steady_clock::now();
+
         if (step.processor) {
             step.processor->process(node_input, node_output, num_samples);
         } else {
             std::memcpy(node_output, node_input, num_samples * sizeof(float));
+        }
+
+        const auto module_end = std::chrono::steady_clock::now();
+
+        if (profiler) {
+            const float elapsed_us =
+                std::chrono::duration<float, std::micro>(module_end - module_start).count();
+
+            profiler->record_module_time(static_cast<int>(step_index), elapsed_us);
         }
     }
 

--- a/src/audio/engine/audio_graph_executor.h
+++ b/src/audio/engine/audio_graph_executor.h
@@ -7,6 +7,7 @@
 
 #include "audio/effects/core/effect.h"
 #include "audio/engine/audio_graph.h"
+#include "audio/engine/dsp_performance_profiler.h"
 
 namespace Amplitron {
 
@@ -78,7 +79,8 @@ class AudioGraphExecutor {
 
     // Hot-path processing (Strictly allocation-free and lock-free)
     // Adjust the pedal->process signature if your pedals process strictly in-place
-    void process(const float* input, float* output, int num_samples);
+    void process(const float* input, float* output, int num_samples,
+                 DspPerformanceProfiler* profiler = nullptr);
     void update_mixer_gain(int node_id, int pin_index, float gain);
 
     std::shared_ptr<Effect> get_effect_by_node_id(int node_id) const {

--- a/src/audio/engine/dsp_performance_profiler.cpp
+++ b/src/audio/engine/dsp_performance_profiler.cpp
@@ -1,0 +1,153 @@
+#include "audio/engine/dsp_performance_profiler.h"
+
+#include <algorithm>
+
+namespace Amplitron {
+
+void DspPerformanceProfiler::begin_callback(int frame_count, int sample_rate, int buffer_size) {
+    frame_count_.store(frame_count, std::memory_order_relaxed);
+    sample_rate_.store(sample_rate, std::memory_order_relaxed);
+    buffer_size_.store(buffer_size, std::memory_order_relaxed);
+
+    const float latency_ms =
+        sample_rate > 0
+            ? (static_cast<float>(buffer_size) / static_cast<float>(sample_rate)) * 1000.0f
+            : 0.0f;
+
+    const float budget_us =
+        sample_rate > 0
+            ? (static_cast<float>(frame_count) / static_cast<float>(sample_rate)) * 1000000.0f
+            : 0.0f;
+
+    latency_ms_.store(latency_ms, std::memory_order_relaxed);
+    callback_budget_us_.store(budget_us, std::memory_order_relaxed);
+}
+
+void DspPerformanceProfiler::record_module_time(int module_index, float elapsed_us) {
+    if (module_index < 0 || module_index >= MAX_PROFILED_MODULES) {
+        return;
+    }
+
+    module_last_us_[module_index].store(elapsed_us, std::memory_order_relaxed);
+
+    const float old_avg = module_average_us_[module_index].load(std::memory_order_relaxed);
+    const float new_avg = old_avg <= 0.0f ? elapsed_us : (old_avg * 0.9f) + (elapsed_us * 0.1f);
+    module_average_us_[module_index].store(new_avg, std::memory_order_relaxed);
+
+    const float old_peak = module_peak_us_[module_index].load(std::memory_order_relaxed);
+    module_peak_us_[module_index].store(std::max(old_peak, elapsed_us), std::memory_order_relaxed);
+
+    int observed_count = module_count_.load(std::memory_order_relaxed);
+    while (module_index + 1 > observed_count &&
+           !module_count_.compare_exchange_weak(observed_count, module_index + 1,
+                                                std::memory_order_relaxed,
+                                                std::memory_order_relaxed)) {
+    }
+}
+
+void DspPerformanceProfiler::end_callback(float callback_duration_us) {
+    callback_duration_us_.store(callback_duration_us, std::memory_order_relaxed);
+
+    const float budget_us = callback_budget_us_.load(std::memory_order_relaxed);
+    const float cpu_percent = budget_us > 0.0f ? (callback_duration_us / budget_us) * 100.0f : 0.0f;
+
+    cpu_load_percent_.store(cpu_percent, std::memory_order_relaxed);
+
+    if (budget_us > 0.0f && callback_duration_us > budget_us) {
+        deadline_miss_count_.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    const uint64_t callback_number = callback_count_.fetch_add(1, std::memory_order_relaxed);
+    const int history_index = static_cast<int>(callback_number % DSP_PROFILER_HISTORY_SIZE);
+
+    latency_history_ms_[history_index].store(latency_ms_.load(std::memory_order_relaxed),
+                                             std::memory_order_relaxed);
+    cpu_history_percent_[history_index].store(cpu_percent, std::memory_order_relaxed);
+
+    history_index_.store((history_index + 1) % DSP_PROFILER_HISTORY_SIZE,
+                         std::memory_order_relaxed);
+}
+
+void DspPerformanceProfiler::record_underrun() {
+    underrun_count_.fetch_add(1, std::memory_order_relaxed);
+}
+
+void DspPerformanceProfiler::record_overrun() {
+    overrun_count_.fetch_add(1, std::memory_order_relaxed);
+}
+
+DspProfilerSnapshot DspPerformanceProfiler::snapshot() const {
+    DspProfilerSnapshot snapshot;
+
+    snapshot.sample_rate = sample_rate_.load(std::memory_order_relaxed);
+    snapshot.history_offset = history_index_.load(std::memory_order_relaxed);
+    snapshot.buffer_size = buffer_size_.load(std::memory_order_relaxed);
+    snapshot.latency_ms = latency_ms_.load(std::memory_order_relaxed);
+    snapshot.callback_budget_us = callback_budget_us_.load(std::memory_order_relaxed);
+    snapshot.callback_duration_us = callback_duration_us_.load(std::memory_order_relaxed);
+    snapshot.cpu_load_percent = cpu_load_percent_.load(std::memory_order_relaxed);
+
+    snapshot.callback_count = callback_count_.load(std::memory_order_relaxed);
+    snapshot.deadline_miss_count = deadline_miss_count_.load(std::memory_order_relaxed);
+    snapshot.underrun_count = underrun_count_.load(std::memory_order_relaxed);
+    snapshot.overrun_count = overrun_count_.load(std::memory_order_relaxed);
+
+    for (int i = 0; i < DSP_PROFILER_HISTORY_SIZE; ++i) {
+        snapshot.latency_history_ms[i] = latency_history_ms_[i].load(std::memory_order_relaxed);
+        snapshot.cpu_history_percent[i] = cpu_history_percent_[i].load(std::memory_order_relaxed);
+    }
+
+    snapshot.module_count =
+        std::min(module_count_.load(std::memory_order_relaxed), MAX_PROFILED_MODULES);
+    const float budget_us = snapshot.callback_budget_us;
+
+    for (int i = 0; i < snapshot.module_count; ++i) {
+        const float last_us = module_last_us_[i].load(std::memory_order_relaxed);
+        const float average_us = module_average_us_[i].load(std::memory_order_relaxed);
+        const float peak_us = module_peak_us_[i].load(std::memory_order_relaxed);
+        const float budget_percent = budget_us > 0.0f ? (last_us / budget_us) * 100.0f : 0.0f;
+
+        snapshot.modules[i].index = i;
+        snapshot.modules[i].last_us = last_us;
+        snapshot.modules[i].average_us = average_us;
+        snapshot.modules[i].peak_us = peak_us;
+        snapshot.modules[i].budget_percent = budget_percent;
+        snapshot.modules[i].overloaded = budget_percent >= 25.0f;
+    }
+
+    return snapshot;
+}
+
+void DspPerformanceProfiler::reset() {
+    sample_rate_.store(0, std::memory_order_relaxed);
+    buffer_size_.store(0, std::memory_order_relaxed);
+    frame_count_.store(0, std::memory_order_relaxed);
+
+    latency_ms_.store(0.0f, std::memory_order_relaxed);
+    callback_budget_us_.store(0.0f, std::memory_order_relaxed);
+    callback_duration_us_.store(0.0f, std::memory_order_relaxed);
+    cpu_load_percent_.store(0.0f, std::memory_order_relaxed);
+
+    callback_count_.store(0, std::memory_order_relaxed);
+    deadline_miss_count_.store(0, std::memory_order_relaxed);
+    underrun_count_.store(0, std::memory_order_relaxed);
+    overrun_count_.store(0, std::memory_order_relaxed);
+    history_index_.store(0, std::memory_order_relaxed);
+    module_count_.store(0, std::memory_order_relaxed);
+
+    for (auto& value : latency_history_ms_) {
+        value.store(0.0f, std::memory_order_relaxed);
+    }
+
+    for (auto& value : cpu_history_percent_) {
+        value.store(0.0f, std::memory_order_relaxed);
+    }
+
+    for (int i = 0; i < MAX_PROFILED_MODULES; ++i) {
+        module_last_us_[i].store(0.0f, std::memory_order_relaxed);
+        module_average_us_[i].store(0.0f, std::memory_order_relaxed);
+        module_peak_us_[i].store(0.0f, std::memory_order_relaxed);
+    }
+}
+
+}  // namespace Amplitron

--- a/src/audio/engine/dsp_performance_profiler.h
+++ b/src/audio/engine/dsp_performance_profiler.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <array>
+#include <atomic>
+#include <cstdint>
+
+namespace Amplitron {
+
+constexpr int DSP_PROFILER_HISTORY_SIZE = 240;
+constexpr int MAX_PROFILED_MODULES = 128;
+
+struct DspProfilerModuleSnapshot {
+    int index = -1;
+    float last_us = 0.0f;
+    float average_us = 0.0f;
+    float peak_us = 0.0f;
+    float budget_percent = 0.0f;
+    bool overloaded = false;
+};
+
+struct DspProfilerSnapshot {
+    int sample_rate = 0;
+    int buffer_size = 0;
+
+    float latency_ms = 0.0f;
+    float callback_budget_us = 0.0f;
+    float callback_duration_us = 0.0f;
+    float cpu_load_percent = 0.0f;
+
+    uint64_t callback_count = 0;
+    uint64_t deadline_miss_count = 0;
+    uint64_t underrun_count = 0;
+    uint64_t overrun_count = 0;
+
+    std::array<float, DSP_PROFILER_HISTORY_SIZE> latency_history_ms{};
+    std::array<float, DSP_PROFILER_HISTORY_SIZE> cpu_history_percent{};
+    int history_offset = 0;
+
+    std::array<DspProfilerModuleSnapshot, MAX_PROFILED_MODULES> modules{};
+    int module_count = 0;
+};
+
+class DspPerformanceProfiler {
+   public:
+    void begin_callback(int frame_count, int sample_rate, int buffer_size);
+    void record_module_time(int module_index, float elapsed_us);
+    void end_callback(float callback_duration_us);
+
+    void record_underrun();
+    void record_overrun();
+
+    DspProfilerSnapshot snapshot() const;
+    void reset();
+
+   private:
+    std::atomic<int> sample_rate_{0};
+    std::atomic<int> buffer_size_{0};
+    std::atomic<int> frame_count_{0};
+
+    std::atomic<float> latency_ms_{0.0f};
+    std::atomic<float> callback_budget_us_{0.0f};
+    std::atomic<float> callback_duration_us_{0.0f};
+    std::atomic<float> cpu_load_percent_{0.0f};
+
+    std::atomic<uint64_t> callback_count_{0};
+    std::atomic<uint64_t> deadline_miss_count_{0};
+    std::atomic<uint64_t> underrun_count_{0};
+    std::atomic<uint64_t> overrun_count_{0};
+
+    std::array<std::atomic<float>, DSP_PROFILER_HISTORY_SIZE> latency_history_ms_{};
+    std::array<std::atomic<float>, DSP_PROFILER_HISTORY_SIZE> cpu_history_percent_{};
+    std::atomic<int> history_index_{0};
+
+    std::array<std::atomic<float>, MAX_PROFILED_MODULES> module_last_us_{};
+    std::array<std::atomic<float>, MAX_PROFILED_MODULES> module_average_us_{};
+    std::array<std::atomic<float>, MAX_PROFILED_MODULES> module_peak_us_{};
+    std::atomic<int> module_count_{0};
+};
+
+}  // namespace Amplitron

--- a/src/audio/engine/i_audio_engine.h
+++ b/src/audio/engine/i_audio_engine.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "audio/backend/audio_device_info.h"
+#include "audio/engine/dsp_performance_profiler.h"
 
 namespace Amplitron {
 
@@ -79,6 +80,13 @@ class IAudioMetricsService {
     virtual bool consume_output_clipped() = 0;
 
     virtual float get_cpu_load() const = 0;
+    virtual DspProfilerSnapshot get_dsp_profiler_snapshot() const { return {}; }
+
+    virtual void reset_dsp_profiler() {}
+
+    virtual void record_profiler_underrun() {}
+
+    virtual void record_profiler_overrun() {}
 };
 
 /**

--- a/src/gui/gui_manager.h
+++ b/src/gui/gui_manager.h
@@ -11,6 +11,7 @@
 #include "gui/commands/command_history.h"
 #include "gui/state/snapshot_manager.h"
 #include "gui/views/gui_analyzer.h"
+#include "gui/views/gui_dsp_profiler.h"
 #include "gui/views/gui_keyboard_shortcuts.h"
 #include "gui/views/gui_midi.h"
 #include "gui/views/gui_presets.h"
@@ -106,6 +107,7 @@ class GuiManager {
 
     // ── Visibility flags (owned here, passed to child render calls) ──
     bool show_settings_ = false;
+    bool show_dsp_profiler_ = false;
     bool show_save_preset_ = false;
     bool show_load_preset_ = false;
     bool show_tuner_ = false;
@@ -117,6 +119,7 @@ class GuiManager {
     // ── Reactive child components ──
     GuiSettings gui_settings_;
     GuiPresets gui_presets_;
+    GuiDspProfiler gui_dsp_profiler_;
     GuiRecording gui_recording_;
     GuiTuner gui_tuner_;
     GuiAnalyzer gui_analyzer_;

--- a/src/gui/gui_manager_frame.cpp
+++ b/src/gui/gui_manager_frame.cpp
@@ -283,6 +283,9 @@ bool GuiManager::run_frame() {
         gui_settings_.set_props(build_settings_props());
         gui_settings_.render(show_settings_);
     }
+    if (show_dsp_profiler_) {
+        gui_dsp_profiler_.render(&show_dsp_profiler_, engine_.get_dsp_profiler_snapshot());
+    }
     if (show_save_preset_) gui_presets_.render_save_popup(show_save_preset_);
     if (show_load_preset_) gui_presets_.render_load_popup(show_load_preset_);
     if (gui_recording_.needs_save_dialog()) {

--- a/src/gui/gui_manager_menu.cpp
+++ b/src/gui/gui_manager_menu.cpp
@@ -286,6 +286,9 @@ void GuiManager::render_menu_bar() {
             if (ImGui::MenuItem("MIDI Settings", nullptr, show_midi_)) {
                 show_midi_ = !show_midi_;
             }
+            if (ImGui::MenuItem("DSP Performance Profiler", nullptr, show_dsp_profiler_)) {
+                show_dsp_profiler_ = !show_dsp_profiler_;
+            }
             ImGui::EndMenu();
         }
         if (ImGui::BeginMenu("Help")) {

--- a/src/gui/update_checker.cpp
+++ b/src/gui/update_checker.cpp
@@ -7,6 +7,16 @@
 
 #include "common.h"
 
+#ifdef _WIN32
+#ifndef popen
+#define popen _popen
+#endif
+
+#ifndef pclose
+#define pclose _pclose
+#endif
+#endif
+
 namespace Amplitron {
 
 UpdateChecker::UpdateChecker() = default;

--- a/src/gui/views/gui_dsp_profiler.cpp
+++ b/src/gui/views/gui_dsp_profiler.cpp
@@ -1,0 +1,138 @@
+#include "gui/views/gui_dsp_profiler.h"
+
+#include <algorithm>
+
+#include "imgui.h"
+
+namespace Amplitron {
+namespace {
+
+const char* load_status_text(float cpu_percent) {
+    if (cpu_percent >= 100.0f) {
+        return "CRITICAL: audio callback is exceeding its real-time budget.";
+    }
+    if (cpu_percent >= 80.0f) {
+        return "WARNING: audio callback is close to the real-time limit.";
+    }
+    return "OK: audio callback is within the real-time budget.";
+}
+
+}  // namespace
+
+void GuiDspProfiler::render(bool* open, const DspProfilerSnapshot& snapshot) {
+    if (!open || !*open) {
+        return;
+    }
+
+    ImGui::SetNextWindowSize(ImVec2(720, 520), ImGuiCond_FirstUseEver);
+
+    if (!ImGui::Begin("DSP Performance Profiler", open)) {
+        ImGui::End();
+        return;
+    }
+
+    ImGui::Text("Real-time DSP performance");
+    ImGui::Separator();
+
+    ImGui::Text("Sample rate: %d Hz", snapshot.sample_rate);
+    ImGui::Text("Buffer size: %d samples", snapshot.buffer_size);
+    ImGui::Text("Estimated latency: %.2f ms", snapshot.latency_ms);
+    ImGui::Text("Callback budget: %.2f us", snapshot.callback_budget_us);
+    ImGui::Text("Last callback time: %.2f us", snapshot.callback_duration_us);
+    ImGui::Text("CPU load: %.1f%%", snapshot.cpu_load_percent);
+
+    const float normalized_cpu = std::clamp(snapshot.cpu_load_percent / 100.0f, 0.0f, 1.0f);
+    ImGui::ProgressBar(normalized_cpu, ImVec2(-1.0f, 0.0f));
+
+    ImGui::Spacing();
+    ImGui::TextWrapped("%s", load_status_text(snapshot.cpu_load_percent));
+
+    if (snapshot.deadline_miss_count > 0) {
+        ImGui::TextWrapped(
+            "Deadline misses detected: %llu. This means the callback exceeded its processing "
+            "budget.",
+            static_cast<unsigned long long>(snapshot.deadline_miss_count));
+    }
+
+    if (snapshot.underrun_count > 0 || snapshot.overrun_count > 0) {
+        ImGui::TextWrapped("Stream warnings: underruns=%llu, overruns=%llu.",
+                           static_cast<unsigned long long>(snapshot.underrun_count),
+                           static_cast<unsigned long long>(snapshot.overrun_count));
+    }
+
+    ImGui::SeparatorText("History");
+
+    float max_latency_history = snapshot.latency_ms;
+    for (float value : snapshot.latency_history_ms) {
+        max_latency_history = std::max(max_latency_history, value);
+    }
+
+    float max_cpu_history = snapshot.cpu_load_percent;
+    for (float value : snapshot.cpu_history_percent) {
+        max_cpu_history = std::max(max_cpu_history, value);
+    }
+
+    const int history_offset = std::clamp(snapshot.history_offset, 0,
+                                          static_cast<int>(snapshot.latency_history_ms.size()) - 1);
+
+    ImGui::PlotLines("Latency history (ms)", snapshot.latency_history_ms.data(),
+                     static_cast<int>(snapshot.latency_history_ms.size()), history_offset, nullptr,
+                     0.0f, std::max(10.0f, max_latency_history * 1.2f), ImVec2(-1.0f, 80.0f));
+
+    ImGui::PlotLines("CPU history (%)", snapshot.cpu_history_percent.data(),
+                     static_cast<int>(snapshot.cpu_history_percent.size()), history_offset, nullptr,
+                     0.0f, std::max(100.0f, max_cpu_history * 1.2f), ImVec2(-1.0f, 80.0f));
+
+    ImGui::SeparatorText("DSP Modules");
+
+    if (snapshot.module_count <= 0) {
+        ImGui::TextWrapped(
+            "No DSP module timings have been recorded yet. Start audio playback to populate this "
+            "table.");
+    } else if (ImGui::BeginTable(
+                   "DspModuleTimingTable", 6,
+                   ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg | ImGuiTableFlags_Resizable)) {
+        ImGui::TableSetupColumn("Module");
+        ImGui::TableSetupColumn("Last us");
+        ImGui::TableSetupColumn("Average us");
+        ImGui::TableSetupColumn("Peak us");
+        ImGui::TableSetupColumn("Budget %");
+        ImGui::TableSetupColumn("Status");
+        ImGui::TableHeadersRow();
+
+        for (int i = 0; i < snapshot.module_count; ++i) {
+            const auto& module = snapshot.modules[i];
+
+            ImGui::TableNextRow();
+
+            ImGui::TableSetColumnIndex(0);
+            ImGui::Text("Node %d", module.index);
+
+            ImGui::TableSetColumnIndex(1);
+            ImGui::Text("%.2f", module.last_us);
+
+            ImGui::TableSetColumnIndex(2);
+            ImGui::Text("%.2f", module.average_us);
+
+            ImGui::TableSetColumnIndex(3);
+            ImGui::Text("%.2f", module.peak_us);
+
+            ImGui::TableSetColumnIndex(4);
+            ImGui::Text("%.1f%%", module.budget_percent);
+
+            ImGui::TableSetColumnIndex(5);
+            ImGui::Text("%s", module.overloaded ? "OVERLOADED" : "OK");
+        }
+
+        ImGui::EndTable();
+    }
+
+    ImGui::Spacing();
+    ImGui::TextWrapped(
+        "Accessibility note: warnings are shown as explicit text labels and table status values, "
+        "not color alone.");
+
+    ImGui::End();
+}
+
+}  // namespace Amplitron

--- a/src/gui/views/gui_dsp_profiler.h
+++ b/src/gui/views/gui_dsp_profiler.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "audio/engine/dsp_performance_profiler.h"
+
+namespace Amplitron {
+
+class GuiDspProfiler {
+   public:
+    void render(bool* open, const DspProfilerSnapshot& snapshot);
+};
+
+}  // namespace Amplitron

--- a/tests/unit/test_dsp_performance_profiler.cpp
+++ b/tests/unit/test_dsp_performance_profiler.cpp
@@ -1,0 +1,283 @@
+#include "audio/engine/dsp_performance_profiler.h"
+#include "gui/views/gui_dsp_profiler.h"
+#include "imgui.h"
+#include "test_framework.h"
+
+using namespace Amplitron;
+using namespace TestFramework;
+
+TEST(DspPerformanceProfiler_DefaultSnapshot) {
+    DspPerformanceProfiler profiler;
+
+    const auto snapshot = profiler.snapshot();
+
+    ASSERT_TRUE(snapshot.sample_rate == 0);
+    ASSERT_TRUE(snapshot.buffer_size == 0);
+    ASSERT_NEAR(snapshot.latency_ms, 0.0f, 0.001f);
+    ASSERT_NEAR(snapshot.callback_budget_us, 0.0f, 0.001f);
+    ASSERT_NEAR(snapshot.cpu_load_percent, 0.0f, 0.001f);
+    ASSERT_TRUE(snapshot.callback_count == 0);
+    ASSERT_TRUE(snapshot.deadline_miss_count == 0);
+    ASSERT_TRUE(snapshot.underrun_count == 0);
+    ASSERT_TRUE(snapshot.overrun_count == 0);
+    ASSERT_TRUE(snapshot.module_count == 0);
+}
+
+TEST(DspPerformanceProfiler_CallbackMetricsAndHistory) {
+    DspPerformanceProfiler profiler;
+
+    profiler.begin_callback(64, 48000, 64);
+    profiler.end_callback(1000.0f);
+
+    const auto snapshot = profiler.snapshot();
+
+    ASSERT_TRUE(snapshot.sample_rate == 48000);
+    ASSERT_TRUE(snapshot.buffer_size == 64);
+    ASSERT_NEAR(snapshot.latency_ms, 1.333f, 0.01f);
+    ASSERT_NEAR(snapshot.callback_budget_us, 1333.333f, 0.1f);
+    ASSERT_NEAR(snapshot.callback_duration_us, 1000.0f, 0.001f);
+    ASSERT_NEAR(snapshot.cpu_load_percent, 75.0f, 0.1f);
+    ASSERT_TRUE(snapshot.callback_count == 1);
+    ASSERT_TRUE(snapshot.deadline_miss_count == 0);
+    ASSERT_TRUE(snapshot.history_offset == 1);
+    ASSERT_NEAR(snapshot.latency_history_ms[0], snapshot.latency_ms, 0.001f);
+    ASSERT_NEAR(snapshot.cpu_history_percent[0], snapshot.cpu_load_percent, 0.001f);
+}
+
+TEST(DspPerformanceProfiler_DeadlineMissAndStreamCounters) {
+    DspPerformanceProfiler profiler;
+
+    profiler.begin_callback(64, 48000, 64);
+    profiler.end_callback(2000.0f);
+    profiler.record_underrun();
+    profiler.record_underrun();
+    profiler.record_overrun();
+
+    const auto snapshot = profiler.snapshot();
+
+    ASSERT_TRUE(snapshot.callback_count == 1);
+    ASSERT_TRUE(snapshot.deadline_miss_count == 1);
+    ASSERT_TRUE(snapshot.underrun_count == 2);
+    ASSERT_TRUE(snapshot.overrun_count == 1);
+    ASSERT_TRUE(snapshot.cpu_load_percent > 100.0f);
+}
+
+TEST(DspPerformanceProfiler_ModuleTimingStats) {
+    DspPerformanceProfiler profiler;
+
+    profiler.begin_callback(64, 48000, 64);
+    profiler.record_module_time(2, 100.0f);
+    profiler.record_module_time(2, 200.0f);
+    profiler.record_module_time(5, 500.0f);
+    profiler.end_callback(900.0f);
+
+    const auto snapshot = profiler.snapshot();
+
+    ASSERT_TRUE(snapshot.module_count >= 6);
+
+    const auto& module_two = snapshot.modules[2];
+    ASSERT_TRUE(module_two.index == 2);
+    ASSERT_NEAR(module_two.last_us, 200.0f, 0.001f);
+    ASSERT_TRUE(module_two.average_us > 100.0f);
+    ASSERT_TRUE(module_two.average_us < 200.0f);
+    ASSERT_NEAR(module_two.peak_us, 200.0f, 0.001f);
+    ASSERT_TRUE(!module_two.overloaded);
+
+    const auto& module_five = snapshot.modules[5];
+    ASSERT_TRUE(module_five.index == 5);
+    ASSERT_NEAR(module_five.last_us, 500.0f, 0.001f);
+    ASSERT_NEAR(module_five.peak_us, 500.0f, 0.001f);
+    ASSERT_TRUE(module_five.budget_percent > 0.0f);
+}
+
+TEST(DspPerformanceProfiler_ResetClearsMetrics) {
+    DspPerformanceProfiler profiler;
+
+    profiler.begin_callback(64, 48000, 64);
+    profiler.record_module_time(1, 300.0f);
+    profiler.record_underrun();
+    profiler.record_overrun();
+    profiler.end_callback(2000.0f);
+
+    profiler.reset();
+
+    const auto snapshot = profiler.snapshot();
+
+    ASSERT_TRUE(snapshot.callback_count == 0);
+    ASSERT_TRUE(snapshot.deadline_miss_count == 0);
+    ASSERT_TRUE(snapshot.underrun_count == 0);
+    ASSERT_TRUE(snapshot.overrun_count == 0);
+    ASSERT_TRUE(snapshot.module_count == 0);
+    ASSERT_TRUE(snapshot.history_offset == 0);
+    ASSERT_NEAR(snapshot.latency_history_ms[0], 0.0f, 0.001f);
+    ASSERT_NEAR(snapshot.cpu_history_percent[0], 0.0f, 0.001f);
+}
+
+TEST(DspPerformanceProfiler_IgnoresInvalidModuleIndexes) {
+    DspPerformanceProfiler profiler;
+
+    profiler.begin_callback(64, 48000, 64);
+    profiler.record_module_time(-1, 100.0f);
+    profiler.record_module_time(MAX_PROFILED_MODULES, 100.0f);
+    profiler.end_callback(100.0f);
+
+    const auto snapshot = profiler.snapshot();
+
+    ASSERT_TRUE(snapshot.module_count == 0);
+    ASSERT_TRUE(snapshot.callback_count == 1);
+}
+
+TEST(DspPerformanceProfiler_HistoryWrapsAndTracksMultipleModules) {
+    DspPerformanceProfiler profiler;
+
+    for (std::size_t i = 0; i < DSP_PROFILER_HISTORY_SIZE + 3; ++i) {
+        profiler.begin_callback(128, 48000, 128);
+        profiler.record_module_time(0, 100.0f + static_cast<float>(i));
+        profiler.record_module_time(1, 200.0f + static_cast<float>(i));
+        profiler.record_module_time(2, 300.0f + static_cast<float>(i));
+        profiler.end_callback(500.0f + static_cast<float>(i));
+    }
+
+    const auto snapshot = profiler.snapshot();
+
+    ASSERT_TRUE(snapshot.sample_rate == 48000);
+    ASSERT_TRUE(snapshot.buffer_size == 128);
+    ASSERT_TRUE(snapshot.callback_count == DSP_PROFILER_HISTORY_SIZE + 3);
+    ASSERT_TRUE(snapshot.history_offset == 3);
+    ASSERT_TRUE(snapshot.module_count >= 3);
+
+    ASSERT_TRUE(snapshot.modules[0].index == 0);
+    ASSERT_TRUE(snapshot.modules[1].index == 1);
+    ASSERT_TRUE(snapshot.modules[2].index == 2);
+
+    ASSERT_TRUE(snapshot.modules[0].last_us > 100.0f);
+    ASSERT_TRUE(snapshot.modules[1].last_us > 200.0f);
+    ASSERT_TRUE(snapshot.modules[2].last_us > 300.0f);
+
+    ASSERT_TRUE(snapshot.modules[0].average_us > 0.0f);
+    ASSERT_TRUE(snapshot.modules[1].average_us > snapshot.modules[0].average_us);
+    ASSERT_TRUE(snapshot.modules[2].average_us > snapshot.modules[1].average_us);
+
+    ASSERT_TRUE(snapshot.modules[0].peak_us >= snapshot.modules[0].last_us);
+    ASSERT_TRUE(snapshot.modules[1].peak_us >= snapshot.modules[1].last_us);
+    ASSERT_TRUE(snapshot.modules[2].peak_us >= snapshot.modules[2].last_us);
+
+    ASSERT_TRUE(snapshot.latency_history_ms[0] > 0.0f);
+    ASSERT_TRUE(snapshot.cpu_history_percent[0] > 0.0f);
+}
+
+class ScopedImGuiContext {
+   public:
+    ScopedImGuiContext()
+        : previous_context_(ImGui::GetCurrentContext()), context_(ImGui::CreateContext()) {
+        ImGui::SetCurrentContext(context_);
+
+        ImGuiIO& io = ImGui::GetIO();
+        io.DisplaySize = ImVec2(800.0f, 600.0f);
+
+        io.Fonts->AddFontDefault();
+        unsigned char* font_pixels = nullptr;
+        int font_width = 0;
+        int font_height = 0;
+        io.Fonts->GetTexDataAsRGBA32(&font_pixels, &font_width, &font_height);
+
+        ASSERT_TRUE(font_pixels != nullptr);
+        ASSERT_TRUE(font_width > 0);
+        ASSERT_TRUE(font_height > 0);
+    }
+
+    ~ScopedImGuiContext() {
+        ImGui::DestroyContext(context_);
+        ImGui::SetCurrentContext(previous_context_);
+    }
+
+   private:
+    ImGuiContext* previous_context_;
+    ImGuiContext* context_;
+};
+
+TEST(GuiDspProfiler_RenderSmoke) {
+    ScopedImGuiContext imgui_context;
+
+    DspProfilerSnapshot snapshot;
+    snapshot.sample_rate = 48000;
+    snapshot.buffer_size = 64;
+    snapshot.latency_ms = 1.33f;
+    snapshot.callback_budget_us = 1333.33f;
+    snapshot.callback_duration_us = 1500.0f;
+    snapshot.cpu_load_percent = 112.5f;
+    snapshot.callback_count = 3;
+    snapshot.deadline_miss_count = 1;
+    snapshot.underrun_count = 1;
+    snapshot.overrun_count = 1;
+    snapshot.history_offset = 2;
+    snapshot.latency_history_ms[0] = 1.33f;
+    snapshot.latency_history_ms[1] = 12.5f;
+    snapshot.cpu_history_percent[0] = 75.0f;
+    snapshot.cpu_history_percent[1] = 112.5f;
+    snapshot.module_count = 2;
+    snapshot.modules[0] = {0, 100.0f, 100.0f, 120.0f, 7.5f, false};
+    snapshot.modules[1] = {1, 500.0f, 450.0f, 600.0f, 37.5f, true};
+
+    bool open = true;
+    GuiDspProfiler view;
+
+    ImGui::NewFrame();
+    view.render(&open, snapshot);
+    ImGui::Render();
+
+    ASSERT_TRUE(open);
+}
+
+TEST(GuiDspProfiler_ClosedWindowSmoke) {
+    ScopedImGuiContext imgui_context;
+
+    bool open = false;
+    DspProfilerSnapshot snapshot;
+    GuiDspProfiler view;
+
+    ImGui::NewFrame();
+    view.render(&open, snapshot);
+    ImGui::Render();
+
+    ASSERT_TRUE(!open);
+}
+
+TEST(GuiDspProfiler_EmptySnapshotSmoke) {
+    ScopedImGuiContext imgui_context;
+
+    bool open = true;
+    DspProfilerSnapshot snapshot;
+    GuiDspProfiler view;
+
+    ImGui::NewFrame();
+    view.render(&open, snapshot);
+    ImGui::Render();
+
+    ASSERT_TRUE(open);
+}
+
+TEST(GuiDspProfiler_NormalLoadSnapshotSmoke) {
+    ScopedImGuiContext imgui_context;
+
+    DspProfilerSnapshot snapshot;
+    snapshot.sample_rate = 48000;
+    snapshot.buffer_size = 128;
+    snapshot.latency_ms = 2.66f;
+    snapshot.callback_budget_us = 2666.67f;
+    snapshot.callback_duration_us = 700.0f;
+    snapshot.cpu_load_percent = 26.25f;
+    snapshot.callback_count = 8;
+    snapshot.history_offset = 4;
+    snapshot.latency_history_ms[0] = 2.66f;
+    snapshot.cpu_history_percent[0] = 26.25f;
+
+    bool open = true;
+    GuiDspProfiler view;
+
+    ImGui::NewFrame();
+    view.render(&open, snapshot);
+    ImGui::Render();
+
+    ASSERT_TRUE(open);
+}


### PR DESCRIPTION
## What does this PR do?

Fixes #117

This PR adds a real-time DSP Performance Profiler for Amplitron with actual audio-thread instrumentation instead of a static/settings-only UI.

The profiler tracks callback latency, callback budget usage, CPU load, deadline misses, underruns/overruns, processing history, and per-DSP-module timing from the graph executor.

### What changed

- Added a dedicated `DspPerformanceProfiler` with fixed-size history buffers and atomic metric storage
- Instrumented `AudioEngine::process_audio()` to record callback budget, callback duration, latency, CPU load, and deadline misses
- Instrumented `AudioGraphExecutor` to record per-DSP-node processing time
- Added PortAudio callback status handling for input/output underflow and overflow
- Added SDL capture queue underrun/overrun monitoring
- Added a visible `Utilities -> DSP Performance Profiler` panel
- Added latency and CPU history graphs
- Added per-module timing table with last, average, peak, budget percentage, and overloaded status
- Added explicit text warnings so the profiler does not rely on color alone
- Added profiler documentation and README feature mention
- Fixed MSVC compatibility for `popen` / `pclose` in the update checker

### Real-time safety

The audio-thread instrumentation avoids:

- heap allocation in the profiler path
- mutex locking
- file I/O
- logging
- command queue changes
- graph topology changes

Profiler data is stored through atomics and fixed-size arrays so the callback can update metrics safely.

## Related Issue

Fixes #117

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor / code cleanup
- [x] 📝 Documentation
- [ ] ✅ Tests
- [x] 🔧 Build / CI / Configuration

## How Was This Tested?

- Platform(s) tested on: Windows 10/11, MSVC Build Tools, CMake/Ninja, vcpkg dependencies
- Test command run:

```
git diff --check
cmake --build build --target Amplitron --parallel
```

- Manual test steps:
   - Launched the app with .\build\Amplitron.exe
   - Opened Utilities -> DSP Performance Profiler
   - Verified the profiler panel opens successfully
   - Verified live display of:
   - sample rate
   - buffer size
   - estimated latency
   - callback budget
   - CPU load
   - latency history graph
   - CPU history graph
   - per-DSP-module timing table
   - text-based status/warning labels


Note: I validated the Amplitron app target locally. I did not mark the full test-suite checkbox because the existing local MSVC amplitron-tests target has unrelated linker/source-list issues.

Checklist
- [x]  Code compiles and builds successfully on my platform
- [ ]  All existing tests pass (./amplitron-tests)
- [ ]  New tests added for new functionality (if applicable)
- [x]  Documentation updated (README, code comments) if applicable
- [x]  No blocking calls on the audio thread (no std::mutex::lock() on the hot path)
- [x]  Tested on: Windows/MSVC with CMake/Ninja

Screenshots / Demo

Added UI panel: `Utilities -> DSP Performance Profiler`

<img width="959" height="539" alt="Screenshot 2026-07-03 204353" src="https://github.com/user-attachments/assets/b05cc2b4-3655-4be2-8351-51bcf0c92fff" />
<br></br>

The profiler displays live latency, CPU budget, CPU load, history graphs, deadline misses, underrun/overrun counters, and per-DSP-module timing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a real-time DSP Performance Profiler with latency, callback budget/duration, CPU load, deadline misses, underruns/overruns, and per-module timing history.
  * Added a **Utilities → DSP Performance Profiler** UI with CPU severity labels, warnings, and a module timing table.
* **Documentation**
  * Added dedicated DSP Performance Profiler documentation and updated README feature/tool listings.
* **Bug Fixes**
  * Improved underrun/overrun profiling and hardened CPU-load calculations (including safer handling when sample rate is invalid).
* **Tests**
  * Added unit coverage for profiler snapshots, counters, module timing aggregation, reset behavior, and GUI render smoke tests.
* **Chores**
  * Updated CI/iOS build flow and improved Windows update-checker compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->