### PR TITLE
fix: defer web MIDI permission until explicitly requested

### DIFF
--- a/src/gui/gui_manager.cpp
+++ b/src/gui/gui_manager.cpp
@@ -65,7 +65,9 @@ bool GuiManager::initialize(int width, int height) {
     if (midi_manager_.mappings().empty()) {
         midi_manager_.install_default_mappings();
     }
+#ifndef __EMSCRIPTEN__
     midi_manager_.initialize();
+#endif
 
 #ifndef AMPLITRON_NO_DESKTOP_SHELL
     update_checker_.start_check();

--- a/src/gui/gui_manager_menu.cpp
+++ b/src/gui/gui_manager_menu.cpp
@@ -285,6 +285,9 @@ void GuiManager::render_menu_bar() {
             }
             if (ImGui::MenuItem("MIDI Settings", nullptr, show_midi_)) {
                 show_midi_ = !show_midi_;
+                if (show_midi_) {
+                    midi_manager_.initialize();
+                }
             }
             if (ImGui::MenuItem("DSP Performance Profiler", nullptr, show_dsp_profiler_)) {
                 show_dsp_profiler_ = !show_dsp_profiler_;
@@ -379,6 +382,9 @@ void GuiManager::render_menu_bar() {
                 }
                 if (ImGui::IsItemClicked()) {
                     show_midi_ = !show_midi_;
+                    if (show_midi_) {
+                        midi_manager_.initialize();
+                    }
                 }
             } else if (it->label == "LIVE") {
                 ImGui::TextColored(Theme::Live(), "%s", it->label.c_str());

--- a/src/gui/views/gui_midi.cpp
+++ b/src/gui/views/gui_midi.cpp
@@ -224,11 +224,7 @@ bool GuiMidi::render_learn_menu_item(const std::string& effect_name,
         }
     }
 
-    if (ImGui::MenuItem("MIDI Learn")) {
-        if (!midi_.initialize()) {
-            return false;
-        }
-
+    if (ImGui::MenuItem("MIDI Learn") && midi_.initialize()) {
         midi_.start_learn(MidiTargetType::EffectParam, effect_name, param_name);
         return true;
     }
@@ -236,11 +232,7 @@ bool GuiMidi::render_learn_menu_item(const std::string& effect_name,
 }
 
 bool GuiMidi::render_learn_bypass_item(const std::string& effect_name) {
-    if (ImGui::MenuItem("MIDI Learn (Bypass)")) {
-        if (!midi_.initialize()) {
-            return false;
-        }
-
+    if (ImGui::MenuItem("MIDI Learn (Bypass)") && midi_.initialize()) {
         midi_.start_learn(MidiTargetType::EffectBypass, effect_name, "");
         return true;
     }

--- a/src/gui/views/gui_midi.cpp
+++ b/src/gui/views/gui_midi.cpp
@@ -225,6 +225,10 @@ bool GuiMidi::render_learn_menu_item(const std::string& effect_name,
     }
 
     if (ImGui::MenuItem("MIDI Learn")) {
+        if (!midi_.initialize()) {
+            return false;
+        }
+
         midi_.start_learn(MidiTargetType::EffectParam, effect_name, param_name);
         return true;
     }
@@ -233,6 +237,10 @@ bool GuiMidi::render_learn_menu_item(const std::string& effect_name,
 
 bool GuiMidi::render_learn_bypass_item(const std::string& effect_name) {
     if (ImGui::MenuItem("MIDI Learn (Bypass)")) {
+        if (!midi_.initialize()) {
+            return false;
+        }
+
         midi_.start_learn(MidiTargetType::EffectBypass, effect_name, "");
         return true;
     }


### PR DESCRIPTION
## What does this PR do?

Defers MIDI initialization in the web/Emscripten build so the browser does not request MIDI access during the first audio-enabling click.

MIDI access is now initialized only when the user explicitly:

- Opens MIDI Settings from the Utilities menu
- Opens MIDI Settings through the MIDI status indicator
- Selects MIDI Learn for an effect parameter
- Selects MIDI Learn for effect bypass

Native desktop builds retain the existing startup MIDI initialization behavior. MIDI Learn is not started when MIDI initialization fails.

## Related Issue

Fixes #404

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor / code cleanup
- [ ] 📝 Documentation
- [ ] ✅ Tests
- [ ] 🔧 Build / CI / Configuration

## How Was This Tested?

- Platform(s) tested on: Windows, PowerShell, Visual Studio 18 2026 CMake generator
- Test command run:

  ```powershell
  cmake --build build --config Release --target amplitron-tests -j 2

- Additional validation:

 ```
clang-format --dry-run --Werror `
  src/gui/gui_manager.cpp `
  src/gui/gui_manager_menu.cpp `
  src/gui/views/gui_midi.cpp
git diff --check
 ```

- The modified source files compiled successfully. The test target later failed during the final linking stage because of 23 unresolved symbols across existing preset, GUI, MIDI, and pedal components. No compilation errors were reported from the files changed by this PR.
- Browser-level permission behavior was not manually tested locally and should be verified through the web build or repository CI.

## Checklist
- [ ]  Code compiles and builds successfully on my platform
- [ ]  All existing tests pass (./amplitron-tests)
- [ ]  New tests added for new functionality (if applicable)
- [ ]  Documentation updated (README, code comments) if applicable
- [x]  No blocking calls on the audio thread (no std::mutex::lock() on the hot path)
- [x]  Tested on: Windows with PowerShell and the Visual Studio 18 2026 CMake generator
Note : 
- The modified source files compiled successfully.
- The test target failed during linking because of 23 existing unresolved symbols unrelated to this change.
- The test executable was therefore not run locally.

## Screenshots / Demo

Not applicable. This change affects browser permission timing and does not introduce a visible UI change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * MIDI settings now initialize correctly when opened from the Utilities menu or status bar.
  * MIDI parameter and bypass learn actions now verify initialization before starting.
  * MIDI initialization is handled appropriately in web builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->