### PR TITLE
Fix: use generic amp model labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Transform your computer into a complete guitar rig. Plug in your guitar via USB 
 | **Overdrive**     | Tube-style asymmetric soft clipping with tone control                                                             |
 | **Distortion**    | Hard clipping with tanh waveshaping and tone filter                                                               |
 | **Equalizer**     | 3-band parametric EQ (Bass/Mid/Treble/Presence) using biquad filters                                              |
-| **Amp Simulator** | Preamp models (Fender Twin, Marshall JCM800, Mesa Rectifier, Roland JC-120) with gain, tone stack, and saturation |
+| **Amp Simulator** | Preamp models (Clean American, British Crunch, High Gain Modern, Jazz Warm) with gain, tone stack, and saturation |
 | **Cabinet Sim**   | Speaker cabinet emulation with low/high rolloff and resonance                                                     |
 | **Chorus**        | LFO-modulated delay with rate and depth controls                                                                  |
 | **Delay**         | Up to 2 seconds, with feedback tone filtering                                                                     |

--- a/docs/PRESETS.md
+++ b/docs/PRESETS.md
@@ -10,37 +10,37 @@ You can load these presets directly from the "Presets" menu in the GUI.
 
 ### `01 Sparkling Clean`
 * **Style:** Lush, shimmering clean tone
-* **Amp Model:** Clean American (Fender Twin)
+* **Amp Model:** Clean American (blackface-style clean combo)
 * **Active Effects:** Noise Gate, Compressor, Chorus, Delay, Reverb, Amp Sim
-* **Use Case:** Perfect for arpeggiated chords, indie pop, and 80s ballads. Uses the Fender Twin emulation along with smooth chorus and warm hall-style reverb.
+* **Use Case:** Perfect for arpeggiated chords, indie pop, and 80s ballads. Uses a sparkling clean combo voice along with smooth chorus and warm hall-style reverb.
 
 ### `02 Classic Rock Crunch`
 * **Style:** Warm, mid-focused driven rock tone
-* **Amp Model:** British Crunch (Marshall JCM800)
+* **Amp Model:** British Crunch (British 800-style crunch)
 * **Active Effects:** Noise Gate, Overdrive, Equalizer, Phaser, Reverb, Amp Sim
-* **Use Case:** Excellent for classic rock rhythm playing, blues solos, and vintage-inspired tones. The Phaser adds classic 70s character to the Marshall punch.
+* **Use Case:** Excellent for classic rock rhythm playing, blues solos, and vintage-inspired tones. The Phaser adds classic 70s character to the mid-forward crunch.
 
 ### `03 Modern Metal Lead`
 * **Style:** High-gain, tight-tracking lead tone
-* **Amp Model:** High Gain Modern (Mesa Boogie Rectifier)
+* **Amp Model:** High Gain Modern (modern high-gain stack)
 * **Active Effects:** Noise Gate, Distortion, Equalizer (mid-scooped), Delay, Reverb, Amp Sim
 * **Use Case:** Fast alternate picking, sweep picking, and heavy breakdowns. The mid-scoop EQ tightens the tone, and the delay adds space without muddiness.
 
 ### `04 Ambient Swells`
 * **Style:** Spatially massive, washed-out tone
-* **Amp Model:** Jazz Warm (Roland JC-120)
+* **Amp Model:** Jazz Warm (solid-state jazz clean)
 * **Active Effects:** Noise Gate, Compressor (high sustain), Equalizer, Chorus, Flanger, Delay, Reverb, Amp Sim
 * **Use Case:** Ambient soundscapes, volume swells, and cinematic textures. Combines thick modulation (chorus + flanger) with long reverb decays for expansive, ethereal tones.
 
 ### `05 Phase Shift Lead`
 * **Style:** Slow, hypnotic phase sweep on a clean tone
-* **Amp Model:** Clean American (Fender Twin)
+* **Amp Model:** Clean American (blackface-style clean combo)
 * **Active Effects:** Noise Gate, Compressor, Equalizer, Phaser, Delay, Reverb, Amp Sim
 * **Use Case:** Classic rock solos, funky chords, and psychedelic textures. Inspired by the legendary MXR Phase 90 in 4-stage mode. Subtle delay adds depth to the sweep.
 
 ### `06 Jet Flanger`
 * **Style:** Dramatic jet-plane flanger sweep with strong resonance
-* **Amp Model:** Jazz Warm (Roland JC-120)
+* **Amp Model:** Jazz Warm (solid-state jazz clean)
 * **Active Effects:** Noise Gate, Compressor, Equalizer, Flanger, Reverb, Amp Sim
 * **Use Case:** Striking on open chords, harmonics, and slow single-note lines. Inspired by the MXR M117R and Boss BF-2. The high flanger feedback creates that classic "jet" effect.
 

--- a/presets/02_Classic_Rock_Crunch.json
+++ b/presets/02_Classic_Rock_Crunch.json
@@ -1,7 +1,7 @@
 {
   "format_version": 1,
   "name": "Classic Rock Crunch",
-  "description": "Warm, mid-focused driven rock tone. Excellent for classic rock rhythm playing or blues solos. Uses the JCM800 emulation.",
+  "description": "Warm, mid-focused driven rock tone. Excellent for classic rock rhythm playing or blues solos. Uses a British 800-style crunch voice.",
   "saved_at": "2026-03-27T12:00:00",
   "input_gain": 0.8,
   "output_gain": 0.8,

--- a/presets/03_Modern_Metal_Lead.json
+++ b/presets/03_Modern_Metal_Lead.json
@@ -1,7 +1,7 @@
 {
   "format_version": 1,
   "name": "Modern Metal Lead",
-  "description": "High-gain, tight tracking lead tone for fast picking and heavy breakdowns. Uses the Mesa Boogie emulation and hard-clipping.",
+  "description": "High-gain, tight tracking lead tone for fast picking and heavy breakdowns. Uses a modern high-gain stack voice and hard-clipping.",
   "saved_at": "2026-03-27T12:00:00",
   "input_gain": 0.85,
   "output_gain": 0.8,

--- a/presets/04_Ambient_Swells.json
+++ b/presets/04_Ambient_Swells.json
@@ -1,7 +1,7 @@
 {
   "format_version": 1,
   "name": "Ambient Swells",
-  "description": "Spatially massive, washed-out tone for ambient soundscapes, volume swells, and cinematic textures. Focuses on the Roland JC-120 emulation.",
+  "description": "Spatially massive, washed-out tone for ambient soundscapes, volume swells, and cinematic textures. Focuses on a solid-state jazz clean voice.",
   "saved_at": "2026-03-27T12:00:00",
   "input_gain": 0.7,
   "output_gain": 0.8,

--- a/src/audio/effects/amp_cab/amp_simulator.cpp
+++ b/src/audio/effects/amp_cab/amp_simulator.cpp
@@ -13,11 +13,11 @@ static EffectRegistrar<AmpSimulator> reg_AmpSimulator("Amp Sim");
 const std::vector<AmpModel>& get_amp_models() {
     static const std::vector<AmpModel> models = {
         // ---------------------------------------------------------
-        // Clean American -- Fender Twin/Deluxe
+        // Clean American -- blackface-style clean combo
         // ---------------------------------------------------------
         {
             "Clean American",
-            "Fender Twin / Deluxe",
+            "Blackface-style clean combo",
             "Sparkling clean, scooped mids, glassy highs",
             200.0f,
             3.0f,
@@ -37,11 +37,11 @@ const std::vector<AmpModel>& get_amp_models() {
             0.0f,
         },
         // ---------------------------------------------------------
-        // British Crunch -- Marshall JCM800
+        // British Crunch -- British 800-style crunch
         // ---------------------------------------------------------
         {
             "British Crunch",
-            "Marshall JCM800",
+            "British 800-style crunch",
             "Warm breakup, mid-forward, classic rock crunch",
             180.0f,
             -1.0f,
@@ -61,11 +61,11 @@ const std::vector<AmpModel>& get_amp_models() {
             0.15f,
         },
         // ---------------------------------------------------------
-        // High Gain Modern -- Mesa Boogie Rectifier
+        // High Gain Modern -- modern high-gain stack
         // ---------------------------------------------------------
         {
             "High Gain Modern",
-            "Mesa Boogie Rectifier",
+            "Modern high-gain stack",
             "Tight low-end, scooped mids, aggressive distortion",
             150.0f,
             1.5f,
@@ -85,11 +85,11 @@ const std::vector<AmpModel>& get_amp_models() {
             0.25f,
         },
         // ---------------------------------------------------------
-        // Jazz Warm -- Roland JC-120
+        // Jazz Warm -- solid-state jazz clean
         // ---------------------------------------------------------
         {
             "Jazz Warm",
-            "Roland JC-120",
+            "Solid-state jazz clean",
             "Flat clean, warm highs rolloff, round tone",
             250.0f,
             2.0f,

--- a/src/audio/effects/amp_cab/amp_simulator.h
+++ b/src/audio/effects/amp_cab/amp_simulator.h
@@ -3,8 +3,7 @@
 // Preamp and tone-stack models for classic guitar amplifier voicings.
 // Signal model: y = L * sat(G * H_tone{x}, mix, asymmetry), where H_tone is
 // a low-shelf + peaking-mid + high-shelf biquad cascade. The factory models
-// cover Clean American / Fender Twin, British Crunch / Marshall JCM800,
-// High Gain Modern / Mesa Rectifier, and Jazz Warm / Roland JC-120. Dynamic
+// cover Clean American, British Crunch, High Gain Modern, and Jazz Warm. Dynamic
 // sag follows an envelope e[n] = a*x_abs[n] + (1-a)*e[n-1] and reduces gain
 // as the simulated supply is loaded.
 
@@ -22,7 +21,7 @@ namespace Amplitron {
  */
 struct AmpModel {
     const char* name;         ///< Display name (e.g. "Clean American")
-    const char* inspiration;  ///< Real-world amp inspiration
+    const char* inspiration;  ///< Generic tonal inspiration
     const char* description;  ///< Short tonal description
 
     // --- Tone stack (3-band biquad EQ) ---

--- a/src/audio/effects/amp_cab/amp_simulator.h
+++ b/src/audio/effects/amp_cab/amp_simulator.h
@@ -62,9 +62,27 @@ const std::vector<AmpModel>& get_amp_models();
  */
 class AmpSimulator : public Effect {
    public:
+    /**
+     * @brief Creates the amp simulator with factory parameters and default coefficients.
+     */
     AmpSimulator();
+
+    /**
+     * @brief Processes a mono audio buffer through the selected amp model.
+     * @param buffer Interleaved-free mono sample buffer to transform in place.
+     * @param num_samples Number of samples available in buffer.
+     */
     void process(float* buffer, int num_samples) override;
+
+    /**
+     * @brief Updates the processing sample rate and refreshes tone-stack coefficients.
+     * @param sample_rate New sample rate in Hz.
+     */
     void set_sample_rate(int sample_rate) override;
+
+    /**
+     * @brief Clears filter, envelope, and smoothing state before playback resumes.
+     */
     void reset() override;
     const char* name() const override { return "Amp Sim"; }
     const char* type_id() const override { return "Amp Sim"; }
@@ -99,6 +117,9 @@ class AmpSimulator : public Effect {
     float cached_treble_ = -999.0f;
     float cached_gain_ = -999.0f;
 
+    /**
+     * @brief Rebuilds tone-stack filter coefficients after model or trim changes.
+     */
     void recompute_coefficients_if_dirty();
 };
 


### PR DESCRIPTION
## **User description**
## Summary
- Replace trademarked amp model secondary labels with generic tonal descriptors in the amp model metadata
- Update README, preset guide, and preset descriptions so the documentation matches the UI language
- Keep the existing descriptive model names and DSP parameter values unchanged

Closes #407

## Validation
- `rg -n Fender|Marshall|Mesa|Boogie|Roland|JC-120|JCM800|Rectifier|Twin|Deluxe .` returns no matches
- Parsed updated preset JSON files with PowerShell `ConvertFrom-Json`
- `git diff --check` passed

## Note
Native CMake/test execution could not be run in this local environment because `cmake` is not installed. The change is limited to display strings and documentation/preset descriptions; CI should cover compiled targets.

## Summary by Sourcery

Use generic amplifier labels throughout the application and its preset documentation.

Enhancements:
- Replace trademarked amplifier references with generic, tone-focused labels across amp metadata, presets, and documentation while preserving existing model names and sound settings.

Documentation:
- Update the README and preset guide to use consistent brand-neutral amplifier descriptions.


___

## **CodeAnt-AI Description**
Use generic, tone-focused amplifier labels throughout the app and presets

### What Changed
- Amp models now display generic descriptions such as “blackface-style clean combo” and “modern high-gain stack” instead of real-world amplifier brand and model names
- Preset descriptions and the preset guide use the same generic amplifier language
- The README now lists the app’s descriptive amp model names without trademarked references
- Amp tones, model names, and DSP settings remain unchanged

### Impact
`✅ Clearer, brand-neutral amp labels`
`✅ Consistent amp names across the UI, presets, and documentation`
`✅ Unchanged guitar tones and preset behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated amp simulator model names and descriptions to use generic tonal categories.
  * Revised preset documentation to reflect clean, crunch, high-gain, and jazz-oriented amp characteristics.
  * Clarified descriptions for classic rock, modern metal, and ambient presets.

* **Bug Fixes**
  * No audio processing, preset settings, or model behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->